### PR TITLE
Adds raw connect functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.3.1
 
+* Feat: Add raw `Connect({Map<String, dynamic>?})` for all platforms
 * Refactor: [Web] Removed unused `web_callkit` event listeners. 
 * Fix: [Web] Check if call SID is present when call is disconnected (this occurs if the call ends abruptly after starting, and `params` does not contain `CallSid`).
 * Fix: [iOS] unregister removes device push token preventing new access token registration (i.e. user 1 logs out, user 2 and more won't receive any calls). Thanks to [@VinceDollo](https://github.com/VinceDollo) & [@Erchil66](https://github.com/Erchil66) [Issue #273](https://github.com/cybex-dev/twilio_voice/issues/273)

--- a/android/src/main/kotlin/com/twilio/twilio_voice/types/TVMethodChannels.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/types/TVMethodChannels.kt
@@ -47,7 +47,8 @@ enum class TVMethodChannels(val method: String) {
     IS_PHONE_ACCOUNT_ENABLED("isPhoneAccountEnabled"),
     REJECT_CALL_ON_NO_PERMISSIONS("rejectCallOnNoPermissions"),
     IS_REJECTING_CALL_ON_NO_PERMISSIONS("isRejectingCallOnNoPermissions"),
-    UPDATE_CALLKIT_ICON("updateCallKitIcon");
+    UPDATE_CALLKIT_ICON("updateCallKitIcon"),
+    CONNECT("connect");
 
     companion object {
         private val map = TVMethodChannels.values().associateBy(TVMethodChannels::method)

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -141,6 +141,21 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
             self.callTo = callTo
             self.identity = callFrom
             makeCall(to: callTo)
+        } else if flutterCall.method == "connect" {
+            guard let callTo = arguments["To"] as? String? else {
+                return
+            }
+            guard let callFrom = arguments["From"] as? String? else {
+                return
+            }
+            self.callArgs = arguments
+            self.callOutgoing = true
+            if let accessToken = arguments["accessToken"] as? String{
+                self.accessToken = accessToken
+            }
+            self.callTo = callTo ?? ""
+            self.identity = callFrom ?? ""
+            makeCall(to: self.callTo)
         }
         else if flutterCall.method == "toggleMute"
         {

--- a/lib/_internal/method_channel/twilio_call_method_channel.dart
+++ b/lib/_internal/method_channel/twilio_call_method_channel.dart
@@ -114,9 +114,12 @@ class MethodChannelTwilioCall extends TwilioCallPlatform {
     return _channel.invokeMethod('isBluetoothOn', <String, dynamic>{});
   }
 
-  /// Only web supported for now.
   @override
   Future<bool?> connect({Map<String, dynamic>? extraOptions}) {
-    return Future.value(false);
+    _activeCall = ActiveCall(from: "", to: "", callDirection: CallDirection.outgoing);
+    final options = {
+      ...?extraOptions,
+    };
+    return _channel.invokeMethod('connect', options);
   }
 }

--- a/lib/_internal/platform_interface/twilio_call_platform_interface.dart
+++ b/lib/_internal/platform_interface/twilio_call_platform_interface.dart
@@ -31,15 +31,9 @@ abstract class TwilioCallPlatform extends SharedPlatformInterface {
   /// [extraOptions] will be added to the callPayload sent to your server
   Future<bool?> place({required String from, required String to, Map<String, dynamic>? extraOptions});
 
-  /// Place outgoing call with raw parameters. Returns true if successful, false otherwise.
-  /// Parameters send to Twilio's REST API endpoint 'makeCall' can be passed in [extraOptions];
-  /// Parameters are reduced to this format
-  /// <code>
-  /// {
-  ///  ...extraOptions
-  /// }
-  /// </code>
-  /// [extraOptions] will be added to the call payload sent to your server
+  /// Places new call using raw parameters passed directly to Twilio's REST API endpoint 'makeCall'. Returns true if successful, false otherwise.
+  ///
+  /// [extraOptions] will be added to the callPayload sent to your server
   Future<bool?> connect({Map<String, dynamic>? extraOptions});
 
   /// Hangs up active call

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -786,14 +786,9 @@ class Call extends MethodChannelTwilioCall {
     return true;
   }
 
-  /// Place outgoing call with raw parameters. Returns true if successful, false otherwise.
-  /// Parameters send to Twilio's REST API endpoint 'makeCall' can be passed in [extraOptions];
-  /// Parameters are reduced to this format
-  /// <code>
-  /// {
-  ///  ...extraOptions
-  /// }
-  /// </code>
+  /// Places new call using raw parameters passed directly to Twilio's REST API endpoint 'makeCall'. Returns true if successful, false otherwise.
+  ///
+  /// [extraOptions] will be added to the callPayload sent to your server
   /// See [twilio_js.Device.connect]
   @override
   Future<bool?> connect({Map<String, dynamic>? extraOptions}) async {

--- a/macos/Classes/JsInterop/Device/TVDeviceConnectOptions.swift
+++ b/macos/Classes/JsInterop/Device/TVDeviceConnectOptions.swift
@@ -6,9 +6,9 @@ public class TVDeviceConnectOptions: JSONArgumentSerializer {
     // TODO(cybex-dev) - add region, edge information, etc.
     var params: [String: String] = [:]
 
-    init(to: String, from: String, customParameters: [String:Any]) {
-        params[Constants.PARAM_TO] = to
-        params[Constants.PARAM_FROM] = from
+    init(to: String?, from: String?, customParameters: [String:Any]) {
+        if(to != nil) params[Constants.PARAM_TO] = to
+        if(from != nil) params[Constants.PARAM_FROM] = from
         let stringMap = customParameters.map({ (key, value) -> (String, String) in
             (key, String(describing: value))
         });

--- a/macos/Classes/TwilioVoiceChannelMethods.swift
+++ b/macos/Classes/TwilioVoiceChannelMethods.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum TwilioVoiceChannelMethods: String {
     case tokens = "tokens"
     case makeCall = "makeCall"
+    case connect = "connect"
     case toggleMute = "toggleMute"
     case isMuted = "isMuted"
     case toggleSpeaker = "toggleSpeaker"

--- a/macos/Classes/TwilioVoicePlugin.swift
+++ b/macos/Classes/TwilioVoicePlugin.swift
@@ -209,7 +209,7 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
     ///   - to: recipient
     ///   - extraOptions: extra options
     ///   - completionHandler: completion handler -> (Bool?)
-    private func place(from: String, to: String, extraOptions: [String: Any]?, completionHandler: @escaping OnCompletionValueHandler<Bool>) -> Void {
+    private func place(from: String?, to: String?, extraOptions: [String: Any]?, completionHandler: @escaping OnCompletionValueHandler<Bool>) -> Void {
         assert(from.isNotEmpty(), "\(Constants.PARAM_FROM) cannot be empty")
         assert(to.isNotEmpty(), "\(Constants.PARAM_TO) cannot be empty")
 //        assert(extraOptions?.keys.contains(Constants.PARAM_FROM) ?? true, "\(Constants.PARAM_FROM) cannot be passed in extraOptions")
@@ -218,7 +218,10 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
 
         logEvent(description: "Making new call")
 
-        var params: [String: Any] = [Constants.PARAM_FROM: from, Constants.PARAM_TO: to]
+        var params: [String: Any] = [
+            if(from != nil) Constants.PARAM_FROM: from,
+            if(to != nil) Constants.PARAM_TO: to,
+        ]
         if let extraOptions = extraOptions {
             params.merge(extraOptions) { (_, new) in
                 new
@@ -583,6 +586,21 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
                 result(ferror)
                 return
             }
+
+            var params: [String: Any] = [:]
+            arguments.forEach { (key, value) in
+                if key != Constants.PARAM_TO && key != Constants.PARAM_FROM {
+                    params[key] = value
+                }
+            }
+
+            place(from: from, to: to, extraOptions: params) { success in
+                result(success ?? false)
+            }
+            break
+        case .connect:
+            guard let to = arguments[Constants.PARAM_TO] as? String?
+            guard let from = arguments[Constants.PARAM_FROM] as? String
 
             var params: [String: Any] = [:]
             arguments.forEach { (key, value) in


### PR DESCRIPTION
Adds the ability to initiate calls using raw connection parameters, allowing greater flexibility in call configuration.

This feature:
- Introduces a new `connect` method on all platforms.
- Enables passing custom parameters directly to Twilio's `makeCall` REST API endpoint.