### PR TITLE
Fixes iOS caller ID display in performStartCallAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next release
+
+* Fix: [iOS] show caller number or interpretted client name for performStartCallAction
+* Docs: update CHANGELOG
+
 ## 0.3.2+1
 
 * Fix: [iOS] Missed call notifications now show caller name (or full number) on title, and "Missed call" text in body. [Issue #299](https://github.com/cybex-dev/twilio_voice/issues/299)

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -930,10 +930,18 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
             }
 
             self.sendPhoneCallEvents(description: "LOG|StartCallAction transaction request successful", isError: false)
+            
+            var callerName: String?
+            if(handle.contains("client:")) {
+                let clientName = handle.replacingOccurrences(of: "client:", with: "")
+                callerName = self.clients[clientName]
+            } else {
+                callerName = handle;
+            }
 
             let callUpdate = CXCallUpdate()
             callUpdate.remoteHandle = callHandle
-            callUpdate.localizedCallerName = self.clients[handle] ?? self.clients["defaultCaller"] ?? self.defaultCaller
+            callUpdate.localizedCallerName = callerName ?? self.clients["defaultCaller"] ?? self.defaultCaller
             callUpdate.supportsDTMF = false
             callUpdate.supportsHolding = true
             callUpdate.supportsGrouping = false


### PR DESCRIPTION
Improves the display of caller information in the `performStartCallAction` on iOS.

- Shows either the caller number or the interpreted client name, providing more informative call notifications.