### PR TITLE
Feat: add internal Twilio Device registration state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next Release
+
+* Feat: [Web] Add Twilio Device [DeviceState] accessor protecting un/registration.
+* Docs: update CHANGELOG
+
 ## 0.3.2+2
 
 * Fix: [iOS] show caller number or interpretted client name for performStartCallAction

--- a/lib/_internal/js/device/device.dart
+++ b/lib/_internal/js/device/device.dart
@@ -82,6 +82,11 @@ class Device extends Twilio {
   /// Documentation: https://www.twilio.com/docs/voice/sdks/javascript/twiliodevice#deviceupdateoptionsoptions
   @JS("updateOptions")
   external void updateOptions(DeviceOptions options);
+
+  /// Get current call status, see [DeviceState]
+  /// Documentation: https://www.twilio.com/docs/voice/sdks/javascript/twiliodevice#devicestate
+  @JS("status")
+  external String state();
 }
 
 /// Device options

--- a/lib/_internal/js/device/device_status.dart
+++ b/lib/_internal/js/device/device_status.dart
@@ -1,0 +1,14 @@
+enum DeviceState {
+  destroyed,
+  unregistered,
+  registering,
+  registered,
+}
+
+DeviceState parseDeviceState(String state) {
+  final lower = state.toLowerCase();
+  return DeviceState.values.firstWhere(
+    (e) => e.name == lower,
+    orElse: () => DeviceState.unregistered,
+  );
+}

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -29,6 +29,7 @@ import 'package:web_callkit/web_callkit_web.dart';
 import '../twilio_voice.dart';
 import './js/js.dart' as twilio_js;
 import 'js/core/enums/device_sound_name.dart';
+import 'js/device/device_status.dart';
 import 'js/utils/js_object_utils.dart';
 import 'local_storage_web/local_storage_web.dart';
 import 'method_channel/twilio_call_method_channel.dart';
@@ -550,6 +551,11 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
       closeProtection: _closeProtection,
       sounds: js_util.jsify(_soundMap),
     );
+  }
+
+  DeviceState getDeviceState(twilio_js.Device device) {
+    final status = device.state();
+    return parseDeviceState(status);
   }
 }
 

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -311,7 +311,12 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
   @override
   Future<bool?> unregister({String? accessToken}) async {
     if (device == null) {
-      return false;
+      return true;
+    }
+    final state = getDeviceState(device!);
+    if(state != DeviceState.registered) {
+      printDebug("Device is not registered, cannot unregister");
+      return true;
     }
     try {
       device?.unregister();


### PR DESCRIPTION
Adds device state tracking and prevents unregistering an already unregistered device.

This isn't a publicly available API yet.