### PR TITLE
Enables token update for active Twilio devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next Release
 
 * Feat: [Web] Add Twilio Device [DeviceState] accessor protecting un/registration.
+* Feat: [Web] Add Twilio Device `updateToken(String)` function to allow updating of active device tokens.
+* Feat: update example.
 * Docs: update CHANGELOG
 
 ## 0.3.2+2

--- a/example/lib/dialogs/update_token_dialog.dart
+++ b/example/lib/dialogs/update_token_dialog.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+class UpdateTokenDialogContent extends StatelessWidget {
+  const UpdateTokenDialogContent({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final textController = TextEditingController();
+    return AlertDialog(
+      title: Text('Paste your new token'),
+      content: SingleChildScrollView(
+        child: ListBody(
+          children: <Widget>[
+            const Text('Paste your new token to continue making calls, you\'ll still receive calls to the current device.'),
+            const SizedBox(height: 16),
+            TextField(
+              controller: textController,
+              decoration: const InputDecoration(
+                border: OutlineInputBorder(),
+                labelText: 'New Token',
+                alignLabelWithHint: true,
+              ),
+              maxLines: 3,
+            ),
+          ],
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop(null); // User chose not to update the token
+          },
+          child: const Text('Cancel'),
+        ),
+        ElevatedButton(
+          onPressed: () {
+            Navigator.of(context).pop(textController.text); // User chose to update the token
+          },
+          child: const Text('Update Token'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/_internal/js/device/device.dart
+++ b/lib/_internal/js/device/device.dart
@@ -87,6 +87,11 @@ class Device extends Twilio {
   /// Documentation: https://www.twilio.com/docs/voice/sdks/javascript/twiliodevice#devicestate
   @JS("status")
   external String state();
+
+  /// Update the device's access token.
+  /// Documentation: https://www.twilio.com/docs/voice/sdks/javascript/twiliodevice#deviceupdatetokentoken
+  @JS("updateToken")
+  external void updateToken(String token);
 }
 
 /// Device options

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -363,6 +363,10 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
     //   }
     // }
     try {
+      final shouldUpdate = device != null && getDeviceState(device!) == DeviceState.registered;
+      if (shouldUpdate) {
+        device!.updateToken(accessToken);
+      } else {
       /// opus set as primary code
       /// https://www.twilio.com/blog/client-javascript-sdk-1-7-ga
       List<String> codecs = ["opus", "pcmu"];
@@ -378,6 +382,7 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
 
       // Register device to accept notifications
       device!.register();
+      }
 
       return true;
     } catch (e) {


### PR DESCRIPTION
Adds functionality to update the Twilio device token without requiring re-registration.

- Introduces a dialog for users to input a new token.
- Implements the `updateToken` method to refresh the token for registered devices on the web platform.
- Updates the example app to demonstrate the new feature.