### PR TITLE
fix: Show missed call notification method handler error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix: [Web] Await Twilio Device `register()` and `unregister()` method calls.
 * Fix: [Web] Prevent duplicate `TwilioVoiceWeb` instances.
 * Feat: [iOS] Add support for call logging via `enableCallLogging(bool)` to record call in recents. No other platform currently supports this, see [NOTES.md](NOTES.md#limitations) for more details.
+* Fix: `showMissedCallNotifications` method call not working due to incorrect method channel name. 
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/lib/_internal/method_channel/twilio_voice_method_channel.dart
+++ b/lib/_internal/method_channel/twilio_voice_method_channel.dart
@@ -48,7 +48,7 @@ class MethodChannelTwilioVoice extends TwilioVoicePlatform {
   /// Setting is persisted across restarts until overridden
   @override
   set showMissedCallNotifications(bool value) {
-    _channel.invokeMethod('show-notifications', <String, dynamic>{"show": value});
+    _channel.invokeMethod('showNotifications', <String, dynamic>{"show": value});
   }
 
   /// Unregisters from Twilio


### PR DESCRIPTION
# Description

Addresses an issue where the `showMissedCallNotifications` method was not functioning correctly due to an incorrect method channel name. This correction ensures that missed call notifications are displayed as expected.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots (if appropriate):