### PR TITLE
fix: plugin registers before the FlutterViewController

### DIFF
--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -80,16 +80,6 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         voipRegistry.desiredPushTypes = Set([PKPushType.voIP])
         
         UNUserNotificationCenter.current().delegate = self
-
-        let appDelegate = UIApplication.shared.delegate
-        guard let controller = appDelegate?.window??.rootViewController as? FlutterViewController else {
-            fatalError("rootViewController is not type FlutterViewController")
-        }
-        let registrar = controller.registrar(forPlugin: "twilio_voice")
-        if let unwrappedRegistrar = registrar {
-            let eventChannel = FlutterEventChannel(name: "twilio_voice/events", binaryMessenger: unwrappedRegistrar.messenger())
-            eventChannel.setStreamHandler(self)
-        }
     }
     
     


### PR DESCRIPTION
> twilio_voice/SwiftTwilioVoicePlugin.swift:83: Fatal error: rootViewController is not type FlutterViewController

the "twilio_voice/events" FlutterEventChannel is registered in `register(with:)` using the registrar Flutter provides. 

Looking up the FlutterViewController here is redundant and crashes under Flutter's UIScene/implicit-engine lifecycle, where plugins register before the FlutterViewController (and the app delegate's window) exist.