### PR TITLE
feat: native call holding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Feat: [iOS] Add support for call logging via `enableCallLogging(bool)` to record call in recents. No other platform currently supports this, see [NOTES.md](NOTES.md#limitations) for more details.
 * Fix: `showMissedCallNotifications` method call not working due to incorrect method channel name.
 * Fix: [Android] fix permission request callback not completing on permission re-request.
+* Fix: [Android] add missing Android Foreground Service `phoneCall`.
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Fix: [Android] failure while connecting to incoming/outgoing call with another call in-progress, `TVConnectionService` now checks for ongoing calls prior to stopping service. 
 * Feat: [Android] support null `From`/`To` parameters in raw `connect()` function.  
 * Feat: [Android] new FCM Token ignored on new token registration, now nowifies `twilio_voice` plugin of updated token.
+* Fix: [Web] code cleanup & refactor 
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * fix: [iOS] use registered notification delegate instead of setting `UNUserNotificationCenter.current().delegate = self` to avoid overwriting other notification delegates.
 * fix: [iOS] add missing "Incoming" call event to unify platform behavior contract for incoming calls.
 * fix: [web] function caching ensuring proper cleanup on calls/devices 
+* fix: [web] improved robustness of functions with active/no calls
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Fix: [iOS] remove duplicate plugin registration [#222](https://github.com/cybex-dev/twilio_voice/issues/222)
 * Feat: [iOS] log incoming push notifications not handled by Twilio SDK
 * fix: [iOS] incorrect parsing of systemVersion in `pushRegistry` delegate for handling push notifications.
+* fix: [iOS] notify callkit of failure to start/answer call or failure to answer completion handler.
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Feat: [Android] support null `From`/`To` parameters in raw `connect()` function.  
 * Feat: [Android] new FCM Token ignored on new token registration, now nowifies `twilio_voice` plugin of updated token.
 * Fix: [Web] code cleanup & refactor 
+* Fix: [iOS] remove unnecessary device token log when failed to register with Twilio
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Fix: [iOS] set and use `DefaultAudioDevice` for audio routing and controlling with Twilio SDK
 * Fix: [iOS] remove duplicate plugin registration [#222](https://github.com/cybex-dev/twilio_voice/issues/222)
 * Feat: [iOS] log incoming push notifications not handled by Twilio SDK
+* fix: [iOS] incorrect parsing of systemVersion in `pushRegistry` delegate for handling push notifications.
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Fix: `showMissedCallNotifications` method call not working due to incorrect method channel name.
 * Fix: [Android] fix permission request callback not completing on permission re-request.
 * Fix: [Android] add missing Android Foreground Service `phoneCall`.
+* Fix: [Android] reactive to microphone permission changes while call is ongoing.
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Fix: [Android] fix permission request callback not completing on permission re-request.
 * Fix: [Android] add missing Android Foreground Service `phoneCall`.
 * Fix: [Android] reactive to microphone permission changes while call is ongoing.
+* Fix: [Android] failure while connecting to incoming/outgoing call with another call in-progress, `TVConnectionService` now checks for ongoing calls prior to stopping service. 
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Fix: [Android] add missing Android Foreground Service `phoneCall`.
 * Fix: [Android] reactive to microphone permission changes while call is ongoing.
 * Fix: [Android] failure while connecting to incoming/outgoing call with another call in-progress, `TVConnectionService` now checks for ongoing calls prior to stopping service. 
+* Feat: [Android] support null `From`/`To` parameters in raw `connect()` function.  
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Fix: [Web] Prevent duplicate `TwilioVoiceWeb` instances.
 * Feat: [iOS] Add support for call logging via `enableCallLogging(bool)` to record call in recents. No other platform currently supports this, see [NOTES.md](NOTES.md#limitations) for more details.
 * Fix: `showMissedCallNotifications` method call not working due to incorrect method channel name.
+* Fix: [Android] fix permission request callback not completing on permission re-request.
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * fix: [iOS] incorrect parsing of systemVersion in `pushRegistry` delegate for handling push notifications.
 * fix: [iOS] notify callkit of failure to start/answer call or failure to answer completion handler.
 * fix: [iOS] keep `CallKit` call mute/hold state in-sync when actions are performed on CallKit UI.
+* fix: [iOS] query `isHolding` only with no event emitted
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@
 * Feat: [Android] support null `From`/`To` parameters in raw `connect()` function.  
 * Feat: [Android] new FCM Token ignored on new token registration, now nowifies `twilio_voice` plugin of updated token.
 * Fix: [Web] code cleanup & refactor 
-* Fix: [iOS] remove unnecessary device token log when failed to register with Twilio
+* Fix: [iOS] remove unnecessary device token log when failed to register with Twilio.
+* Fix: [iOS] send hex-formatted device token to Dart.
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Feat: [iOS] log incoming push notifications not handled by Twilio SDK
 * fix: [iOS] incorrect parsing of systemVersion in `pushRegistry` delegate for handling push notifications.
 * fix: [iOS] notify callkit of failure to start/answer call or failure to answer completion handler.
+* fix: [iOS] keep `CallKit` call mute/hold state in-sync when actions are performed on CallKit UI.
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * fix: [iOS] notify callkit of failure to start/answer call or failure to answer completion handler.
 * fix: [iOS] keep `CallKit` call mute/hold state in-sync when actions are performed on CallKit UI.
 * fix: [iOS] query `isHolding` only with no event emitted
+* feat: [iOS] CallKit controller used for mute / hold call actions 
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Fix: [macOS] fix future hanging when placing call and an error occurs/not registered with Twilio.
 * Fix: [iOS] set and use `DefaultAudioDevice` for audio routing and controlling with Twilio SDK
 * Fix: [iOS] remove duplicate plugin registration [#222](https://github.com/cybex-dev/twilio_voice/issues/222)
+* Feat: [iOS] log incoming push notifications not handled by Twilio SDK
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * fix: [iOS] unable to disable call logging on iOS due to incorrect parameter from method channel args. 
 * fix: [iOS] use registered notification delegate instead of setting `UNUserNotificationCenter.current().delegate = self` to avoid overwriting other notification delegates.
 * fix: [iOS] add missing "Incoming" call event to unify platform behavior contract for incoming calls.
+* fix: [web] function caching ensuring proper cleanup on calls/devices 
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Feat: [iOS] add missing event to notify of updated device push token
 * Fix: [iOS] remove invalid push token
 * Fix: [iOS] align parameters for `makeCall` as required or throw malformed with type checks
+* Fix: [macOS] fix future hanging when placing call and an error occurs/not registered with Twilio.
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * fix: [iOS] add missing "Incoming" call event to unify platform behavior contract for incoming calls.
 * fix: [web] function caching ensuring proper cleanup on calls/devices 
 * fix: [web] improved robustness of functions with active/no calls
+* fix: [web] custom parameters are correctly resolved when call is answered
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Fix: [iOS] remove unnecessary device token log when failed to register with Twilio.
 * Fix: [iOS] send hex-formatted device token to Dart.
 * Feat: [iOS] add missing event to notify of updated device push token
+* Fix: [iOS] remove invalid push token
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Fix: [iOS] send hex-formatted device token to Dart.
 * Feat: [iOS] add missing event to notify of updated device push token
 * Fix: [iOS] remove invalid push token
+* Fix: [iOS] align parameters for `makeCall` as required or throw malformed with type checks
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Fix: [Android] reactive to microphone permission changes while call is ongoing.
 * Fix: [Android] failure while connecting to incoming/outgoing call with another call in-progress, `TVConnectionService` now checks for ongoing calls prior to stopping service. 
 * Feat: [Android] support null `From`/`To` parameters in raw `connect()` function.  
+* Feat: [Android] new FCM Token ignored on new token registration, now nowifies `twilio_voice` plugin of updated token.
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * fix: [iOS] query `isHolding` only with no event emitted
 * feat: [iOS] CallKit controller used for mute / hold call actions
 * fix: [iOS] unable to disable call logging on iOS due to incorrect parameter from method channel args. 
+* fix: [iOS] use registered notification delegate instead of setting `UNUserNotificationCenter.current().delegate = self` to avoid overwriting other notification delegates.
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * feat: [iOS] CallKit controller used for mute / hold call actions
 * fix: [iOS] unable to disable call logging on iOS due to incorrect parameter from method channel args. 
 * fix: [iOS] use registered notification delegate instead of setting `UNUserNotificationCenter.current().delegate = self` to avoid overwriting other notification delegates.
+* fix: [iOS] add missing "Incoming" call event to unify platform behavior contract for incoming calls.
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@
 * fix: [iOS] notify callkit of failure to start/answer call or failure to answer completion handler.
 * fix: [iOS] keep `CallKit` call mute/hold state in-sync when actions are performed on CallKit UI.
 * fix: [iOS] query `isHolding` only with no event emitted
-* feat: [iOS] CallKit controller used for mute / hold call actions 
+* feat: [iOS] CallKit controller used for mute / hold call actions
+* fix: [iOS] unable to disable call logging on iOS due to incorrect parameter from method channel args. 
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 * Fix: [Android] add missing Android Foreground Service `phoneCall`.
 * Fix: [Android] reactive to microphone permission changes while call is ongoing.
 * Fix: [Android] failure while connecting to incoming/outgoing call with another call in-progress, `TVConnectionService` now checks for ongoing calls prior to stopping service. 
-* Feat: [Android] support null `From`/`To` parameters in raw `connect()` function.  
+* Feat: [Android, macOS] support null `From`/`To` parameters in raw `connect()` function.  
 * Feat: [Android] new FCM Token ignored on new token registration, now nowifies `twilio_voice` plugin of updated token.
 * Fix: [Web] code cleanup & refactor 
 * Fix: [iOS] remove unnecessary device token log when failed to register with Twilio.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Fix: [Web] code cleanup & refactor 
 * Fix: [iOS] remove unnecessary device token log when failed to register with Twilio.
 * Fix: [iOS] send hex-formatted device token to Dart.
+* Feat: [iOS] add missing event to notify of updated device push token
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 * Fix: [iOS] remove invalid push token
 * Fix: [iOS] align parameters for `makeCall` as required or throw malformed with type checks
 * Fix: [macOS] fix future hanging when placing call and an error occurs/not registered with Twilio.
+* Fix: [iOS] set and use `DefaultAudioDevice` for audio routing and controlling with Twilio SDK
+* Fix: [iOS] remove duplicate plugin registration [#222](https://github.com/cybex-dev/twilio_voice/issues/222)
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -9,12 +9,13 @@
     <uses-permission android:name="android.permission.CALL_PHONE" />
     <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" />
 
     <application>
         <service
             android:name=".service.TVConnectionService"
             android:exported="true"
-            android:foregroundServiceType="microphone"
+            android:foregroundServiceType="phoneCall|microphone"
             android:label="@string/connection_service_name"
             android:permission="android.permission.BIND_TELECOM_CONNECTION_SERVICE">
             <intent-filter>

--- a/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
@@ -1109,8 +1109,11 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
         connect: Boolean = false
     ): Boolean {
         assert(accessToken.isNotEmpty()) { "Twilio Access Token cannot be empty" }
-        assert(!connect && (to == null || to.isNotEmpty())) { "To cannot be empty" }
-        assert(!connect && (from == null || from.isNotEmpty())) { "From cannot be empty" }
+        // Raw connect() calls may omit To/From entirely (the TwiML app decides routing);
+        // only regular makeCall requires them. The previous expressions were inverted and
+        // would have failed for every raw connect had assertions been enabled.
+        assert(connect || !to.isNullOrEmpty()) { "To cannot be empty" }
+        assert(connect || !from.isNullOrEmpty()) { "From cannot be empty" }
 
         telecomManager?.let { tm ->
             if (!tm.hasCallCapableAccount(ctx, TVConnectionService::class.java.name)) {

--- a/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
@@ -3,6 +3,7 @@ package com.twilio.twilio_voice
 import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.app.Application
 import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
@@ -252,6 +253,16 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
                     Log.d(TAG, "onRequestPermissionsResult: Microphone foreground permission granted: $granted");
                 });
                 logEventPermission("Microphone", true)
+
+                // If a call's foreground service is already running (started before the mic
+                // permission was granted), refresh its foreground service types so the
+                // microphone type is added mid-call.
+                context?.let { ctx ->
+                    Intent(ctx, TVConnectionService::class.java).apply {
+                        action = TVConnectionService.ACTION_REFRESH_FOREGROUND_SERVICE_TYPES
+                        ctx.startService(this)
+                    }
+                }
             } else {
                 Log.d(TAG, "Microphone permission not granted")
                 logEventPermission("Microphone", false)
@@ -1318,17 +1329,45 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
     }
 
     //region Flutter ActivityPluginBinding
+    /**
+     * Catches microphone grants made outside the plugin's own permission flow (e.g. the user
+     * enabling the mic in system Settings mid-call): when the app comes back to the
+     * foreground during an active call with the mic granted, refresh the call's foreground
+     * service types so the microphone type can join. The refresh is idempotent - if the
+     * types are already up to date, re-issuing startForeground is a no-op.
+     */
+    private val activityLifecycleListener = object : Application.ActivityLifecycleCallbacks {
+        override fun onActivityResumed(resumedActivity: Activity) {
+            if (resumedActivity != activity) return
+            if (TVConnectionService.hasActiveCalls() && resumedActivity.hasMicrophoneAccess()) {
+                Intent(resumedActivity, TVConnectionService::class.java).apply {
+                    action = TVConnectionService.ACTION_REFRESH_FOREGROUND_SERVICE_TYPES
+                    resumedActivity.startService(this)
+                }
+            }
+        }
+
+        override fun onActivityCreated(a: Activity, savedInstanceState: Bundle?) {}
+        override fun onActivityStarted(a: Activity) {}
+        override fun onActivityPaused(a: Activity) {}
+        override fun onActivityStopped(a: Activity) {}
+        override fun onActivitySaveInstanceState(a: Activity, outState: Bundle) {}
+        override fun onActivityDestroyed(a: Activity) {}
+    }
+
     override fun onAttachedToActivity(activityPluginBinding: ActivityPluginBinding) {
         Log.d(TAG, "onAttachedToActivity")
         activity = activityPluginBinding.activity
         activityPluginBinding.addOnNewIntentListener(this)
         activityPluginBinding.addRequestPermissionsResultListener(this)
+        activityPluginBinding.activity.application.registerActivityLifecycleCallbacks(activityLifecycleListener)
         registerReceiver()
     }
 
     override fun onDetachedFromActivityForConfigChanges() {
         Log.d(TAG, "onDetachedFromActivityForConfigChanges")
         unregisterReceiver()
+        activity?.application?.unregisterActivityLifecycleCallbacks(activityLifecycleListener)
         activity = null
     }
 
@@ -1337,12 +1376,14 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
         activity = activityPluginBinding.activity
         activityPluginBinding.addRequestPermissionsResultListener(this)
         activityPluginBinding.addOnNewIntentListener(this)
+        activityPluginBinding.activity.application.registerActivityLifecycleCallbacks(activityLifecycleListener)
         registerReceiver()
     }
 
     override fun onDetachedFromActivity() {
         Log.d(TAG, "onDetachedFromActivity")
         unregisterReceiver()
+        activity?.application?.unregisterActivityLifecycleCallbacks(activityLifecycleListener)
         activity = null
     }
     //endregion

--- a/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
@@ -22,6 +22,7 @@ import androidx.core.content.ContextCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.twilio.twilio_voice.constants.Constants
 import com.twilio.twilio_voice.constants.FlutterErrorCodes
+import com.twilio.twilio_voice.fcm.VoiceFirebaseMessagingService
 import com.twilio.twilio_voice.receivers.TVBroadcastReceiver
 import com.twilio.twilio_voice.service.TVConnectionService
 import com.twilio.twilio_voice.storage.Storage
@@ -1402,6 +1403,8 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
                 addAction(TVBroadcastReceiver.ACTION_CALL_STATE)
                 addAction(TVBroadcastReceiver.ACTION_INCOMING_CALL_IGNORED)
 
+                addAction(VoiceFirebaseMessagingService.ACTION_NEW_TOKEN)
+
                 addAction(TVNativeCallActions.ACTION_ANSWERED)
                 addAction(TVNativeCallActions.ACTION_REJECTED)
                 addAction(TVNativeCallActions.ACTION_DTMF)
@@ -1965,6 +1968,29 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
             TVNativeCallEvents.EVENT_MISSED -> {
                 logEvent("", "Missed Call")
                 logEvent("", "Call Ended")
+            }
+
+            VoiceFirebaseMessagingService.ACTION_NEW_TOKEN -> {
+                val newToken = intent.getStringExtra(VoiceFirebaseMessagingService.EXTRA_FCM_TOKEN) ?: run {
+                    Log.e(TAG, "handleBroadcastIntent: ACTION_NEW_TOKEN is missing String EXTRA_FCM_TOKEN")
+                    return
+                }
+                if (newToken == fcmToken) {
+                    return
+                }
+                Log.d(TAG, "handleBroadcastIntent: FCM token rotated")
+                fcmToken = newToken
+
+                // Re-register the rotated token with Twilio using the cached access token.
+                // Without this, Twilio keeps the stale binding and incoming calls silently
+                // stop until the app's next `tokens` call. If no access token is cached yet
+                // (engine restarted), registration is healed by the next `tokens` call.
+                accessToken?.let { token ->
+                    registerForCallInvites(token, newToken)
+                }
+
+                // Notify Dart (OnDeviceTokenChanged) so the app can persist the new token.
+                logEvent(Constants.kDEVICETOKEN, newToken)
             }
 
             else -> {

--- a/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
@@ -237,12 +237,12 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
     ): Boolean {
         Log.d(TAG, "onRequestPermissionsResult: $requestCode")
 
-        if (permissions.isNotEmpty()) {
-            permissionResultHandler[requestCode]?.let { handler ->
-                val granted = grantResults[0] == PackageManager.PERMISSION_GRANTED
-                handler(granted)
-                permissionResultHandler.remove(requestCode)
-            }
+        permissionResultHandler.remove(requestCode)?.let { handler ->
+            // Empty arrays mean the request was cancelled by the system (e.g. interaction
+            // interrupted) — treat as denied rather than leaking the handler, which would
+            // leave the awaiting Dart Future hanging.
+            val granted = grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED
+            handler(granted)
         }
 
         if (requestCode == REQUEST_CODE_MICROPHONE) {
@@ -1623,21 +1623,32 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
         }
 
         logEvent("requestPermissionFor$permissionName")
+        permissionResultHandler[requestCode] = onPermissionResult
+
         val shouldShowRationale = ActivityCompat.shouldShowRequestPermissionRationale(activity!!, manifestPermission)
         if (shouldShowRationale) {
+            var proceedClicked = false
             val clickListener =
-                DialogInterface.OnClickListener { _: DialogInterface?, _: Int ->
+                DialogInterface.OnClickListener { dialog: DialogInterface?, _: Int ->
+                    proceedClicked = true
+                    dialog?.dismiss()
+                }
+            val dismissListener = DialogInterface.OnDismissListener { _: DialogInterface? ->
+                if (proceedClicked) {
+                    logEvent("Request" + permissionName + "Access")
                     ActivityCompat.requestPermissions(
                         activity!!, arrayOf(manifestPermission), requestCode
                     )
+                } else {
+                    // Cancelled or dismissed without proceeding: complete the pending result
+                    // as denied instead of leaving the Dart Future hanging.
+                    logEvent("Request" + permissionName + "AccessDismissed")
+                    permissionResultHandler.remove(requestCode)?.invoke(false)
                 }
-            val dismissListener = DialogInterface.OnDismissListener { _: DialogInterface? ->
-                logEvent("Request" + permissionName + "Access")
             }
             showPermissionRationaleDialog(activity!!, "$permissionName Permissions", description, clickListener, dismissListener)
         } else {
             ActivityCompat.requestPermissions(activity!!, arrayOf(manifestPermission), requestCode)
-            permissionResultHandler[requestCode] = onPermissionResult
         }
     }
 

--- a/android/src/main/kotlin/com/twilio/twilio_voice/fcm/VoiceFirebaseMessagingService.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/fcm/VoiceFirebaseMessagingService.kt
@@ -46,10 +46,15 @@ class VoiceFirebaseMessagingService : FirebaseMessagingService(), MessageListene
 
 
     override fun onNewToken(token: String) {
-        val intent = Intent(ACTION_NEW_TOKEN).also {
-            it.putExtra(EXTRA_FCM_TOKEN, token)
+        Log.d(TAG, "onNewToken: FCM token rotated")
+        // Deliver via LocalBroadcastManager to TwilioVoicePlugin (when the app is running) so
+        // it can re-register the rotated token with Twilio and notify the Dart side. The
+        // previous global implicit broadcast reached no receiver on API 26+, silently losing
+        // the rotation until the app's next `tokens` call.
+        Intent(ACTION_NEW_TOKEN).apply {
+            putExtra(EXTRA_FCM_TOKEN, token)
+            LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(this)
         }
-        sendBroadcast(intent)
     }
 
     /**

--- a/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
@@ -26,8 +26,10 @@ import com.twilio.twilio_voice.types.BundleExtensions.getParcelableSafe
 import com.twilio.twilio_voice.types.CallDirection
 import com.twilio.twilio_voice.types.CompletionHandler
 import com.twilio.twilio_voice.types.ContextExtension.appName
+import com.twilio.twilio_voice.types.ContextExtension.checkPermission
 import com.twilio.twilio_voice.types.ContextExtension.hasCallPhonePermission
 import com.twilio.twilio_voice.types.ContextExtension.hasManageOwnCallsPermission
+import com.twilio.twilio_voice.types.ContextExtension.hasMicrophoneAccess
 import com.twilio.twilio_voice.types.IntentExtension.getParcelableExtraSafe
 import com.twilio.twilio_voice.types.TelecomManagerExtension.getPhoneAccountHandle
 import com.twilio.twilio_voice.types.TelecomManagerExtension.hasCallCapableAccount
@@ -115,6 +117,14 @@ class TVConnectionService : ConnectionService() {
          * Action used to poll the ConnectionService for the active call handle.
          */
         const val ACTION_ACTIVE_HANDLE: String = "ACTION_ACTIVE_HANDLE"
+
+        /**
+         * Action used to re-issue [startForeground] with recomputed foreground service types,
+         * e.g. after RECORD_AUDIO is granted mid-call so the microphone type can be added to
+         * the already-running service (a foreground service's types are fixed at the last
+         * [startForeground] call, not re-evaluated when permissions change).
+         */
+        const val ACTION_REFRESH_FOREGROUND_SERVICE_TYPES: String = "ACTION_REFRESH_FOREGROUND_SERVICE_TYPES"
         //endregion
 
         //region EXTRA_* Constants
@@ -472,6 +482,18 @@ class TVConnectionService : ConnectionService() {
                 ACTION_ACTIVE_HANDLE -> {
                     val activeCallHandle = getActiveCallHandle()
                     sendBroadcastCallHandle(applicationContext, activeCallHandle)
+                }
+
+                ACTION_REFRESH_FOREGROUND_SERVICE_TYPES -> {
+                    // Re-issue startForeground with recomputed types so e.g. the microphone
+                    // type joins a call whose foreground service was started before
+                    // RECORD_AUDIO was granted.
+                    if (hasActiveCalls()) {
+                        startForegroundService()
+                    } else {
+                        // Nothing to refresh; don't leave a needlessly started service behind.
+                        stopSelfSafe()
+                    }
                 }
 
                 else -> {

--- a/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
@@ -46,7 +46,12 @@ class TVConnectionService : ConnectionService() {
 
         val TWI_SCHEME: String = "twi"
 
-        val SERVICE_TYPE_MICROPHONE: Int = 100
+        /**
+         * Notification id used for the foreground-service (ongoing call) notification.
+         */
+        const val FOREGROUND_NOTIFICATION_ID: Int = 100
+
+        val SERVICE_TYPE_MICROPHONE: Int = FOREGROUND_NOTIFICATION_ID
 
         //region ACTIONS_* Constants
         /**
@@ -759,7 +764,7 @@ class TVConnectionService : ConnectionService() {
 
     private fun cancelNotification() {
         val notificationManager: NotificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.cancel(SERVICE_TYPE_MICROPHONE)
+        notificationManager.cancel(FOREGROUND_NOTIFICATION_ID)
     }
 
     /// Source: https://github.com/react-native-webrtc/react-native-callkeep/blob/master/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java#L295
@@ -767,11 +772,29 @@ class TVConnectionService : ConnectionService() {
         val notification = createNotification()
         Log.d(TAG, "[VoiceConnectionService] Starting foreground service")
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                // Optional for Android +11, required for Android +14
-                startForeground(SERVICE_TYPE_MICROPHONE, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                // phoneCall: the correct type for a ConnectionService-managed call. Its
+                // prerequisite (MANAGE_OWN_CALLS) is a manifest permission, so the service
+                // can always start with this type - including from the background on an
+                // incoming FCM push, where a microphone-typed start is restricted.
+                var serviceTypes = ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL
+                // microphone: keeps mic access alive while the app is backgrounded mid-call
+                // (Android 11+ while-in-use restrictions). Only added when:
+                //  - RECORD_AUDIO is already granted (starting a microphone-typed FGS without
+                //    it throws a SecurityException on Android 14+), and
+                //  - the FOREGROUND_SERVICE_MICROPHONE permission is present in the merged
+                //    manifest (API 34+). Apps that prefer a phoneCall-only foreground service
+                //    (e.g. to avoid the Play Console microphone FGS declaration) can remove it
+                //    with: <uses-permission android:name=
+                //    "android.permission.FOREGROUND_SERVICE_MICROPHONE" tools:node="remove"/>
+                val hasFgsMicPermission = Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE ||
+                        checkPermission(android.Manifest.permission.FOREGROUND_SERVICE_MICROPHONE)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && hasMicrophoneAccess() && hasFgsMicPermission) {
+                    serviceTypes = serviceTypes or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+                }
+                startForeground(FOREGROUND_NOTIFICATION_ID, notification, serviceTypes)
             } else {
-                startForeground(SERVICE_TYPE_MICROPHONE, notification)
+                startForeground(FOREGROUND_NOTIFICATION_ID, notification)
             }
         } catch (e: Exception) {
             Log.w(TAG, "[VoiceConnectionService] Can't start foreground service : $e")
@@ -782,7 +805,9 @@ class TVConnectionService : ConnectionService() {
     private fun stopForegroundService() {
         Log.d(TAG, "[VoiceConnectionService] stopForegroundService")
         try {
-            stopForeground(SERVICE_TYPE_MICROPHONE)
+            // STOP_FOREGROUND_REMOVE is a flags value; previously the notification id (100)
+            // was passed here, which is not a valid flag.
+            stopForeground(STOP_FOREGROUND_REMOVE)
             cancelNotification()
         } catch (e: java.lang.Exception) {
             Log.w(TAG, "[VoiceConnectionService] can't stop foreground service :$e")

--- a/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
@@ -629,12 +629,8 @@ class TVConnectionService : ConnectionService() {
         // Set call disconnected listener, removes connection from active connections when call is disconnected
         val onCallInitializingDisconnectedListener: CompletionHandler<DisconnectCause> = CompletionHandler {
             connection.twilioCall?.let {
-                if (activeConnections.containsKey(it.sid)) {
-                    activeConnections.remove(it.sid)
-                }
                 sendBroadcastEvent(applicationContext, TVBroadcastReceiver.ACTION_CALL_ENDED, it.sid ?: "", connection.extras)
-                stopForegroundService()
-                stopSelfSafe()
+                onConnectionEnded(it.sid)
             }
         }
 
@@ -667,6 +663,25 @@ class TVConnectionService : ConnectionService() {
     }
 
     /**
+     * Tears down state for a single ended connection: removes it from [activeConnections]
+     * and only demotes the service (stopForeground + stopSelf) once no active calls remain.
+     * With concurrent calls, ending one call must not demote the service - the remaining
+     * call still depends on the foreground state for its process priority and (Android 11+)
+     * background microphone access.
+     * @param callSid The SID of the ended connection, or null if it never received one
+     * (e.g. a connection that failed during creation).
+     */
+    private fun onConnectionEnded(callSid: String?) {
+        callSid?.let { activeConnections.remove(it) }
+        if (!hasActiveCalls()) {
+            stopForegroundService()
+            stopSelf()
+        } else {
+            Log.d(TAG, "onConnectionEnded: ${activeConnections.size} call(s) still active, keeping foreground service")
+        }
+    }
+
+    /**
      * Attach call event listeners to the given connection. This includes responding to call events, call actions and when call has ended.
      * @param connection The connection to attach the listeners to.
      * @param callSid The call SID of the connection.
@@ -683,19 +698,11 @@ class TVConnectionService : ConnectionService() {
             sendBroadcastCallHandle(applicationContext, extra?.getString(TVBroadcastReceiver.EXTRA_CALL_HANDLE))
         }
         val onDisconnect: CompletionHandler<DisconnectCause> = CompletionHandler {
-            if (activeConnections.containsKey(callSid)) {
-                activeConnections.remove(callSid)
-            }
-            stopForegroundService()
-            stopSelfSafe()
+            onConnectionEnded(callSid)
         }
         val onCallState: CompletionHandler<Call.State> = CompletionHandler { state ->
             if (state == Call.State.DISCONNECTED) {
-                if (activeConnections.containsKey(callSid)) {
-                    activeConnections.remove(callSid)
-                }
-                stopForegroundService()
-                stopSelfSafe()
+                onConnectionEnded(callSid)
             }
         }
 
@@ -744,13 +751,17 @@ class TVConnectionService : ConnectionService() {
     override fun onCreateOutgoingConnectionFailed(connectionManagerPhoneAccount: PhoneAccountHandle?, request: ConnectionRequest?) {
         super.onCreateOutgoingConnectionFailed(connectionManagerPhoneAccount, request)
         Log.d(TAG, "onCreateOutgoingConnectionFailed")
-        stopForegroundService()
+        // The failed connection was never added to activeConnections; only demote the
+        // service if no other call is active.
+        onConnectionEnded(null)
     }
 
     override fun onCreateIncomingConnectionFailed(connectionManagerPhoneAccount: PhoneAccountHandle?, request: ConnectionRequest?) {
         super.onCreateIncomingConnectionFailed(connectionManagerPhoneAccount, request)
         Log.d(TAG, "onCreateIncomingConnectionFailed")
-        stopForegroundService()
+        // The failed connection was never added to activeConnections; only demote the
+        // service if no other call is active.
+        onConnectionEnded(null)
     }
 
     private fun getOrCreateChannel(): NotificationChannel {

--- a/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
@@ -428,7 +428,9 @@ class TVConnectionService : ConnectionService() {
                         putBundle(TelecomManager.EXTRA_OUTGOING_CALL_EXTRAS, myBundle)
                     }
 
-                    val address: Uri = Uri.fromParts(PhoneAccount.SCHEME_TEL, to, null)
+                    // Raw connect() calls have no To; use an empty address rather than
+                    // passing null into the Uri.
+                    val address: Uri = Uri.fromParts(PhoneAccount.SCHEME_TEL, to ?: "", null)
                     telecomManager.placeCall(address, extras)
                 }
 
@@ -557,25 +559,26 @@ class TVConnectionService : ConnectionService() {
         super.onCreateOutgoingConnection(connectionManagerPhoneAccount, request)
         Log.d(TAG, "onCreateOutgoingConnection")
 
-        val extras = request?.extras
-        val myBundle: Bundle = extras?.getBundle(EXTRA_OUTGOING_PARAMS) ?: run {
-            Log.e(TAG, "onCreateOutgoingConnection: request is missing Bundle EXTRA_OUTGOING_PARAMS")
-            throw Exception("onCreateOutgoingConnection: request is missing Bundle EXTRA_OUTGOING_PARAMS");
+        // Never throw from a ConnectionService callback: it runs in a Telecom binder callback
+        // and an uncaught exception kills the process. Invalid requests return a failed
+        // Connection instead, which Telecom tears down gracefully.
+        fun failedConnection(reason: String): Connection {
+            Log.e(TAG, "onCreateOutgoingConnection: $reason")
+            sendBroadcastEvent(applicationContext, TVBroadcastReceiver.ACTION_CALL_ENDED, "")
+            return Connection.createFailedConnection(DisconnectCause(DisconnectCause.ERROR, reason))
         }
 
-        // check required EXTRA_TOKEN, EXTRA_TO, EXTRA_FROM
-        val token: String = myBundle.getString(EXTRA_TOKEN) ?: run {
-            Log.e(TAG, "onCreateOutgoingConnection: ACTION_PLACE_OUTGOING_CALL is missing String EXTRA_TOKEN")
-            throw Exception("onCreateOutgoingConnection: ACTION_PLACE_OUTGOING_CALL is missing String EXTRA_TOKEN");
-        }
-        val to = myBundle.getString(EXTRA_TO) ?: run {
-            Log.e(TAG, "onCreateOutgoingConnection: ACTION_PLACE_OUTGOING_CALL is missing String EXTRA_TO")
-            throw Exception("onCreateOutgoingConnection: ACTION_PLACE_OUTGOING_CALL is missing String EXTRA_TO");
-        }
-        val from = myBundle.getString(EXTRA_FROM) ?: run {
-            Log.e(TAG, "onCreateOutgoingConnection: ACTION_PLACE_OUTGOING_CALL is missing String EXTRA_FROM")
-            throw Exception("onCreateOutgoingConnection: ACTION_PLACE_OUTGOING_CALL is missing String EXTRA_FROM");
-        }
+        val myBundle: Bundle = request?.extras?.getBundle(EXTRA_OUTGOING_PARAMS)
+            ?: return failedConnection("request is missing Bundle EXTRA_OUTGOING_PARAMS")
+
+        val token: String = myBundle.getString(EXTRA_TOKEN)
+            ?: return failedConnection("ACTION_PLACE_OUTGOING_CALL is missing String EXTRA_TOKEN")
+
+        // To/From are deliberately absent for raw connect() calls (EXTRA_CONNECT_RAW): all
+        // routing parameters travel in EXTRA_OUTGOING_PARAMS and the TwiML application
+        // decides the destination, so both are optional here.
+        val to = myBundle.getString(EXTRA_TO)
+        val from = myBundle.getString(EXTRA_FROM)
 
         // Get all params from bundle
         val params = HashMap<String, String>()
@@ -589,8 +592,8 @@ class TVConnectionService : ConnectionService() {
                 }
             }
         }
-        params["From"] = from
-        params["To"] = to
+        from?.let { params["From"] = it }
+        to?.let { params["To"] = it }
 
         // create connect options
         val connectOptions = ConnectOptions.Builder(token)
@@ -612,8 +615,8 @@ class TVConnectionService : ConnectionService() {
                 val call = connection.twilioCall!!
                 val callSid = call.sid!!
 
-                // Resolve call parameters
-                val callParams = TVCallParametersImpl(mStorage, call, to, from, params)
+                // Resolve call parameters (raw connect() calls carry no explicit To/From)
+                val callParams = TVCallParametersImpl(mStorage, call, to ?: "", from ?: "", params)
                 connection.setCallParameters(callParams)
 
                 // If call is not attached, attach it

--- a/example/ios/Flutter/ephemeral/flutter_lldb_helper.py
+++ b/example/ios/Flutter/ephemeral/flutter_lldb_helper.py
@@ -1,0 +1,32 @@
+#
+# Generated file, do not edit.
+#
+
+import lldb
+
+def handle_new_rx_page(frame: lldb.SBFrame, bp_loc, extra_args, intern_dict):
+    """Intercept NOTIFY_DEBUGGER_ABOUT_RX_PAGES and touch the pages."""
+    base = frame.register["x0"].GetValueAsAddress()
+    page_len = frame.register["x1"].GetValueAsUnsigned()
+
+    # Note: NOTIFY_DEBUGGER_ABOUT_RX_PAGES will check contents of the
+    # first page to see if handled it correctly. This makes diagnosing
+    # misconfiguration (e.g. missing breakpoint) easier.
+    data = bytearray(page_len)
+    data[0:8] = b'IHELPED!'
+
+    error = lldb.SBError()
+    frame.GetThread().GetProcess().WriteMemory(base, data, error)
+    if not error.Success():
+        print(f'Failed to write into {base}[+{page_len}]', error)
+        return
+
+def __lldb_init_module(debugger: lldb.SBDebugger, _):
+    target = debugger.GetDummyTarget()
+    # Caveat: must use BreakpointCreateByRegEx here and not
+    # BreakpointCreateByName. For some reasons callback function does not
+    # get carried over from dummy target for the later.
+    bp = target.BreakpointCreateByRegex("^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$")
+    bp.SetScriptCallbackFunction('{}.handle_new_rx_page'.format(__name__))
+    bp.SetAutoContinue(True)
+    print("-- LLDB integration loaded --")

--- a/example/ios/Flutter/ephemeral/flutter_lldbinit
+++ b/example/ios/Flutter/ephemeral/flutter_lldbinit
@@ -1,0 +1,5 @@
+#
+# Generated file, do not edit.
+#
+
+command script import --relative-to-command-file flutter_lldb_helper.py

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -357,7 +357,7 @@ class _AppState extends State<App> {
     return Scaffold(
       appBar: AppBar(
         title: const Text("Plugin example app"),
-        actionsPadding: const EdgeInsets.symmetric(horizontal: 8),
+        // actionsPadding: const EdgeInsets.symmetric(horizontal: 8),
         actions: [
           if (twilioInit) ...[
             const _UpdateTokenAction(),

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -13,8 +13,8 @@ import firebase_messaging
 import twilio_voice
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  FLTFirebaseFunctionsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFunctionsPlugin"))
-  FLTFirebaseAnalyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAnalyticsPlugin"))
+  FirebaseFunctionsPlugin.register(with: registry.registrar(forPlugin: "FirebaseFunctionsPlugin"))
+  FirebaseAnalyticsPlugin.register(with: registry.registrar(forPlugin: "FirebaseAnalyticsPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
 				8A62DC9A1F9E4301CB23CA4A /* [CP] Embed Pods Frameworks */,
+				40A4F72FAC44E79EA25FCA2C /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -205,7 +206,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					33CC10EC2044A3C60003C045 = {
@@ -294,6 +295,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
+		};
+		40A4F72FAC44E79EA25FCA2C /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		8A62DC9A1F9E4301CB23CA4A /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/example/macos/Runner/AppDelegate.swift
+++ b/example/macos/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
     override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         print("App Delegate")

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -84,8 +84,6 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         
         voipRegistry.delegate = self
         voipRegistry.desiredPushTypes = Set([PKPushType.voIP])
-        
-        UNUserNotificationCenter.current().delegate = self
     }
     
     
@@ -591,7 +589,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
     func unregister() {
         
         guard let deviceToken = deviceToken, let token = accessToken else {
-            self.sendPhoneCallEvents(description: "LOG|Missing required parameters to unregister", isError: true)
+            self.sendPhoneCallEvents(description: "LOG|Missing required parameters to unregister", isError: false)
             return
         }
         
@@ -807,7 +805,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
     public func callDidDisconnect(call: Call, error: Error?) {
         self.sendPhoneCallEvents(description: "Call Ended", isError: false)
         if let error = error {
-            self.sendPhoneCallEvents(description: "Call Failed: \(error.localizedDescription)", isError: true)
+            self.sendPhoneCallEvents(description: "LOG|Call Failed: \(error.localizedDescription)", isError: false)
         }
 
         if !self.userInitiatedDisconnect {
@@ -1059,7 +1057,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         
         callKitCallController.request(transaction) { error in
             if let error = error {
-                self.sendPhoneCallEvents(description: "End Call Failed: \(error.localizedDescription).", isError: true)
+                self.sendPhoneCallEvents(description: "LOG|End Call Failed: \(error.localizedDescription).", isError: false)
             } else {
                 self.sendPhoneCallEvents(description: "Call Ended", isError: false)
             }
@@ -1151,7 +1149,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
 
     public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         let userInfo = response.notification.request.content.userInfo
-        
+
         if let type = userInfo["type"] as? String, type == "twilio-missed-call", let user = userInfo["From"] as? String{
             self.callTo = user
             if let to = userInfo["To"] as? String{

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -86,16 +86,6 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         voipRegistry.desiredPushTypes = Set([PKPushType.voIP])
         
         UNUserNotificationCenter.current().delegate = self
-
-        let appDelegate = UIApplication.shared.delegate
-        guard let controller = appDelegate?.window??.rootViewController as? FlutterViewController else {
-            fatalError("rootViewController is not type FlutterViewController")
-        }
-        let registrar = controller.registrar(forPlugin: "twilio_voice")
-        if let unwrappedRegistrar = registrar {
-            let eventChannel = FlutterEventChannel(name: "twilio_voice/events", binaryMessenger: unwrappedRegistrar.messenger())
-            eventChannel.setStreamHandler(self)
-        }
     }
     
     

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -117,7 +117,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
             }
             self.accessToken = token;
             guard let deviceToken = deviceToken else {
-                self.sendPhoneCallEvents(description: "LOG|Device token is nil. Cannot register for VoIP push notifications.", isError: true)
+                self.sendPhoneCallEvents(description: "LOG|Device token is nil. Cannot register for VoIP push notifications.", isError: false)
                 return
             }
             if let token = accessToken {

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -900,6 +900,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
                 provider.reportOutgoingCall(with: action.callUUID, connectedAt: Date())
             } else {
                 self.sendPhoneCallEvents(description: "LOG|provider:performVoiceCall() failed", isError: false)
+                provider.reportCall(with: action.callUUID, endedAt: Date(), reason: .failed)
             }
         }
         action.fulfill()
@@ -916,6 +917,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
                 self.sendPhoneCallEvents(description: "LOG|provider:performAnswerVoiceCall() successful", isError: false)
             } else {
                 self.sendPhoneCallEvents(description: "LOG|provider:performAnswerVoiceCall() failed:", isError: false)
+                provider.reportCall(with: action.callUUID, endedAt: Date(), reason: .failed)
             }
         }
 
@@ -1082,6 +1084,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
             }
         } else {
             self.sendPhoneCallEvents(description: "LOG|No CallInvite matches the UUID", isError: false)
+            completionHandler(false)
         }
     }
     

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -943,6 +943,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         self.sendPhoneCallEvents(description: "LOG|provider:performSetHeldAction:", isError: false)
         if let call = self.call {
             call.isOnHold = action.isOnHold
+            self.sendPhoneCallEvents(description: action.isOnHold ? "Hold" : "Unhold", isError: false)
             action.fulfill()
         } else {
             action.fail()
@@ -954,6 +955,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
 
         if let call = self.call {
             call.isMuted = action.isMuted
+            self.sendPhoneCallEvents(description: action.isMuted ? "Mute" : "Unmute", isError: false)
             action.fulfill()
         } else {
             action.fail()

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -377,7 +377,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
             result(updateCallKitIcon(icon: newIcon))
             return
         } else if flutterCall.method == "enableCallLogging" {
-            let value = arguments["enabled"] as? Bool ?? true
+            let value = arguments["enable"] as? Bool ?? true
             
             result(updateEnableCallLogging(value))
             return

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -542,6 +542,13 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
          return true;
      }
     
+    /// Formats an APNs push token as a hex string for the DEVICETOKEN| event. The raw token
+    /// is opaque binary: decoding it as UTF-8 yields replacement characters, and a 0x7C byte
+    /// would collide with the '|' event separator.
+    private func hexString(_ data: Data) -> String {
+        return data.map { String(format: "%02x", $0) }.joined()
+    }
+
     public func pushRegistry(_ registry: PKPushRegistry, didInvalidatePushTokenFor type: PKPushType) {
         self.sendPhoneCallEvents(description: "LOG|pushRegistry:didInvalidatePushTokenForType:", isError: false)
         
@@ -760,7 +767,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         self.sendPhoneCallEvents(description: "Call Ended", isError: false)
         if(error.localizedDescription.contains("Access Token expired")){
             if let deviceToken = deviceToken {
-                self.sendPhoneCallEvents(description: "DEVICETOKEN|\(String(decoding: deviceToken, as: UTF8.self))", isError: false)
+                self.sendPhoneCallEvents(description: "DEVICETOKEN|\(hexString(deviceToken))", isError: false)
             }
         }
         if let completion = self.callKitCompletionCallback {

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -311,13 +311,13 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
             
         }else if flutterCall.method == "hangUp"{
             // Hang up on-going/active call
-            if (self.call != nil) {
+            if let uuid = self.call?.uuid {
                 self.sendPhoneCallEvents(description: "LOG|hangUp method invoked", isError: false)
                 self.userInitiatedDisconnect = true
-                performEndCallAction(uuid: self.call!.uuid!)
+                performEndCallAction(uuid: uuid)
                 //self.toggleUIState(isEnabled: false, showCallControl: false)
-            } else if(self.callInvite != nil) {
-                performEndCallAction(uuid: self.callInvite!.uuid)
+            } else if let invite = self.callInvite {
+                performEndCallAction(uuid: invite.uuid)
             }
         }else if flutterCall.method == "registerClient"{
             guard let clientId = arguments["id"] as? String, let clientName =  arguments["name"] as? String else {return}
@@ -545,7 +545,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
       * will return true, else false.
       */
      func registrationRequired() -> Bool {
-         guard let lastBindingCreated = UserDefaults.standard.object(forKey: kCachedBindingDate) else {
+         guard let lastBindingCreated = UserDefaults.standard.object(forKey: kCachedBindingDate) as? Date else {
              self.sendPhoneCallEvents(description: "LOG|Registration required: true, last binding date not found", isError: false)
              return true
          }
@@ -553,7 +553,9 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
          let date = Date()
          var components = DateComponents()
          components.setValue(kRegistrationTTLInDays/2, for: .day)
-         let expirationDate = Calendar.current.date(byAdding: components, to: lastBindingCreated as! Date)!
+         guard let expirationDate = Calendar.current.date(byAdding: components, to: lastBindingCreated) else {
+             return true
+         }
 
          if expirationDate.compare(date) == ComparisonResult.orderedDescending {
              self.sendPhoneCallEvents(description: "LOG|Registration required: false, half of TTL not passed", isError: false)
@@ -796,7 +798,9 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         }
 
 
-        callKitProvider.reportCall(with: call.uuid!, endedAt: Date(), reason: CXCallEndedReason.failed)
+        if let uuid = call.uuid {
+            callKitProvider.reportCall(with: uuid, endedAt: Date(), reason: CXCallEndedReason.failed)
+        }
         callDisconnected()
     }
 
@@ -813,7 +817,9 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
                 reason = .failed
             }
 
-            self.callKitProvider.reportCall(with: call.uuid!, endedAt: Date(), reason: reason)
+            if let uuid = call.uuid {
+                self.callKitProvider.reportCall(with: uuid, endedAt: Date(), reason: reason)
+            }
         }
 
         callDisconnected()

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -605,7 +605,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
      */
     public func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, for type: PKPushType) {
         self.sendPhoneCallEvents(description: "LOG|pushRegistry:didReceiveIncomingPushWithPayload:forType:", isError: false)
-        
+
         if (type == PKPushType.voIP) {
             if !TwilioVoiceSDK.handleNotification(payload.dictionaryPayload, delegate: self, delegateQueue: nil) {
                 self.sendPhoneCallEvents(description: "LOG|Unhandled VoIP push: not a valid Twilio Voice notification", isError: false)
@@ -627,8 +627,9 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
                 self.sendPhoneCallEvents(description: "LOG|Unhandled VoIP push: not a valid Twilio Voice notification", isError: false)
             }
         }
-        
-        if let version = Float(UIDevice.current.systemVersion), version < 13.0 {
+
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+        if osVersion.majorVersion < 13 {
             // Save for later when the notification is properly handled.
             self.incomingPushCompletionCallback = completion
         } else {

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -607,7 +607,9 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         self.sendPhoneCallEvents(description: "LOG|pushRegistry:didReceiveIncomingPushWithPayload:forType:", isError: false)
         
         if (type == PKPushType.voIP) {
-            TwilioVoiceSDK.handleNotification(payload.dictionaryPayload, delegate: self, delegateQueue: nil)
+            if !TwilioVoiceSDK.handleNotification(payload.dictionaryPayload, delegate: self, delegateQueue: nil) {
+                self.sendPhoneCallEvents(description: "LOG|Unhandled VoIP push: not a valid Twilio Voice notification", isError: false)
+            }
         }
     }
     
@@ -621,7 +623,9 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
 //        self.incomingPushCompletionCallback = completion
         
         if (type == PKPushType.voIP) {
-            TwilioVoiceSDK.handleNotification(payload.dictionaryPayload, delegate: self, delegateQueue: nil)
+            if !TwilioVoiceSDK.handleNotification(payload.dictionaryPayload, delegate: self, delegateQueue: nil) {
+                self.sendPhoneCallEvents(description: "LOG|Unhandled VoIP push: not a valid Twilio Voice notification", isError: false)
+            }
         }
         
         if let version = Float(UIDevice.current.systemVersion), version < 13.0 {

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -434,7 +434,9 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         // Cancel the previous call before making another one.
         if (self.call != nil) {
             self.userInitiatedDisconnect = true
-            performEndCallAction(uuid: self.call!.uuid!)            
+            if let uuid = self.call?.uuid {
+                performEndCallAction(uuid: uuid)
+            }
         } else {
             let uuid = UUID()
             

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -552,12 +552,19 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
 
     public func pushRegistry(_ registry: PKPushRegistry, didInvalidatePushTokenFor type: PKPushType) {
         self.sendPhoneCallEvents(description: "LOG|pushRegistry:didInvalidatePushTokenForType:", isError: false)
-        
+
         if (type != .voIP) {
             return
         }
-        
+
         self.unregister()
+
+        // The push token is no longer valid: drop the cached token and binding date so a
+        // later `tokens` call cannot re-register the dead token with Twilio. (unregister()
+        // above reads the cached token synchronously before this runs.) A fresh token
+        // arrives via pushRegistry(didUpdate:) when PushKit issues new credentials.
+        UserDefaults.standard.removeObject(forKey: kCachedDeviceToken)
+        UserDefaults.standard.removeObject(forKey: kCachedBindingDate)
     }
     
     func unregister() {

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -52,7 +52,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
     var callKitCallController: CXCallController
     var userInitiatedDisconnect: Bool = false
     var callOutgoing: Bool = false
-    
+
     static var appName: String {
         get {
             return (Bundle.main.infoDictionary!["CFBundleName"] as? String) ?? "Define CFBundleName"
@@ -77,6 +77,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         //super.init(coder: aDecoder)
         super.init()
 
+        TwilioVoiceSDK.audioDevice = audioDevice
         
         callKitProvider.setDelegate(self, queue: nil)
         _ = updateCallKitIcon(icon: defaultIcon)
@@ -892,6 +893,9 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
     public func provider(_ provider: CXProvider, perform action: CXStartCallAction) {
         self.sendPhoneCallEvents(description: "LOG|provider:performStartCallAction:", isError: false)
 
+        // in the event of device disabled from previous call ending while new call is connecting, we check
+        // CXCallObserver for any new/active calls besides our current call to set audio device enabled state
+        audioDevice.isEnabled = hasOtherCalls(besides: action.callUUID)
 
         provider.reportOutgoingCall(with: action.callUUID, startedConnectingAt: Date())
 
@@ -909,6 +913,8 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
     public func provider(_ provider: CXProvider, perform action: CXAnswerCallAction) {
         self.sendPhoneCallEvents(description: "LOG|provider:performAnswerCallAction:", isError: false)
 
+        // AudioDevice may be active, but has not yet started for this call i.e. we keep previous state.
+        audioDevice.isEnabled = hasOtherCalls(besides: action.callUUID)
 
         self.performAnswerVoiceCall(uuid: action.callUUID) { (success) in
             if success {

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -507,7 +507,6 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
             TwilioVoiceSDK.register(accessToken: token, deviceToken: deviceToken) { (error) in
                 if let error = error {
                     self.sendPhoneCallEvents(description: "LOG|An error occurred while registering: \(error.localizedDescription)", isError: false)
-                    self.sendPhoneCallEvents(description: "DEVICETOKEN|\(String(decoding: deviceToken, as: UTF8.self))", isError: false)
                 }
                 else {
                     self.sendPhoneCallEvents(description: "LOG|Successfully registered for VoIP push notifications.", isError: false)

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -172,17 +172,27 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         }
         else if flutterCall.method == "toggleMute"
         {
-            guard let muted = arguments["muted"] as? Bool else {return}
-            if (self.call != nil) {
-
-                self.call!.isMuted = muted
-                guard let eventSink = eventSink else {
-                    return
+            guard let muted = arguments["muted"] as? Bool else {
+                result(FlutterError(code: "MALFORMED_ARGUMENTS", message: "No 'muted' argument provided or invalid type", details: nil))
+                return
+            }
+            guard let call = self.call, let uuid = call.uuid else {
+                result(FlutterError(code: "MUTE_ERROR", message: "No call to be muted", details: nil))
+                return
+            }
+            // Route through CallKit so the system call UI stays in sync. The
+            // CXSetMutedCallAction handler applies the state to the Twilio call and
+            // emits the Mute/Unmute event.
+            let muteAction = CXSetMutedCallAction(call: uuid, muted: muted)
+            callKitCallController.request(CXTransaction(action: muteAction)) { error in
+                DispatchQueue.main.async {
+                    if let error = error {
+                        self.sendPhoneCallEvents(description: "LOG|Failed to set mute state: \(error.localizedDescription)", isError: false)
+                        result(FlutterError(code: "MUTE_ERROR", message: error.localizedDescription, details: nil))
+                    } else {
+                        result(true)
+                    }
                 }
-                eventSink(muted ? "Mute" : "Unmute")
-            } else {
-                let ferror: FlutterError = FlutterError(code: "MUTE_ERROR", message: "No call to be muted", details: nil)
-                _result!(ferror)
             }
         }
         else if flutterCall.method == "isMuted"
@@ -245,22 +255,30 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
          self.identity = clientIdentity;
          } */
         else if flutterCall.method == "holdCall" {
-            guard let shouldHold = arguments["shouldHold"] as? Bool else {return}
-            
-            if (self.call != nil) {
-                let hold = self.call!.isOnHold
-                if(shouldHold && !hold) {
-                    self.call!.isOnHold = true
-                    guard let eventSink = eventSink else {
-                        return
+            guard let shouldHold = arguments["shouldHold"] as? Bool else {
+                result(FlutterError(code: "MALFORMED_ARGUMENTS", message: "No 'shouldHold' argument provided or invalid type", details: nil))
+                return
+            }
+            guard let call = self.call, let uuid = call.uuid else {
+                result(false)
+                return
+            }
+            if (call.isOnHold == shouldHold) {
+                result(true)
+                return
+            }
+            // Route through CallKit so the system call UI stays in sync. The
+            // CXSetHeldCallAction handler applies the state to the Twilio call and
+            // emits the Hold/Unhold event.
+            let holdAction = CXSetHeldCallAction(call: uuid, onHold: shouldHold)
+            callKitCallController.request(CXTransaction(action: holdAction)) { error in
+                DispatchQueue.main.async {
+                    if let error = error {
+                        self.sendPhoneCallEvents(description: "LOG|Failed to set hold state: \(error.localizedDescription)", isError: false)
+                        result(false)
+                    } else {
+                        result(true)
                     }
-                    eventSink("Hold")
-                } else if(!shouldHold && hold) {
-                    self.call!.isOnHold = false
-                    guard let eventSink = eventSink else {
-                        return
-                    }
-                    eventSink("Unhold")
                 }
             }
         }

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -155,10 +155,14 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
             self.identity = callFrom
             makeCall(to: callTo)
         } else if flutterCall.method == "connect" {
+            // Raw connect: To/From are optional (routing decided by the TwiML app). The
+            // double-optional cast only fails when a value is present with a wrong type.
             guard let callTo = arguments["To"] as? String? else {
+                result(FlutterError(code: "MALFORMED_ARGUMENTS", message: "'To' argument has invalid type", details: nil))
                 return
             }
             guard let callFrom = arguments["From"] as? String? else {
+                result(FlutterError(code: "MALFORMED_ARGUMENTS", message: "'From' argument has invalid type", details: nil))
                 return
             }
             self.callArgs = arguments

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -265,20 +265,11 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
             }
         }
         else if flutterCall.method == "isHolding" {
-            // guard call not nil
-            guard let call = self.call else {
-                return;
+            if(self.call != nil) {
+                result(self.call!.isOnHold);
+            } else {
+                result(false);
             }
-            
-            // toggle state current state
-            let isOnHold = call.isOnHold;
-            call.isOnHold = !isOnHold;
-            
-            // guard event sink not nil & post update
-            guard let eventSink = eventSink else {
-                return
-            }
-            eventSink(!isOnHold ? "Hold" : "Unhold")
         }
         else if flutterCall.method == "answer" {
             if(self.callInvite != nil) {

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -516,6 +516,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         self.deviceToken = deviceToken
         UserDefaults.standard.set(Date(), forKey: kCachedBindingDate)
 
+        self.sendPhoneCallEvents(description: "DEVICETOKEN|\(hexString(deviceToken))", isError: false)
     }
     
     /**

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -108,7 +108,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
     public func handle(_ flutterCall: FlutterMethodCall, result: @escaping FlutterResult) {
         _result = result
         
-        let arguments:Dictionary<String, AnyObject> = flutterCall.arguments as! Dictionary<String, AnyObject>;
+        let arguments: Dictionary<String, AnyObject> = flutterCall.arguments as? Dictionary<String, AnyObject> ?? [:]
         
         if flutterCall.method == "tokens" {
             guard let token = arguments["accessToken"] as? String else {

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -678,6 +678,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         var from:String = callInvite.from ?? defaultCaller
         from = from.replacingOccurrences(of: "client:", with: "")
         
+        self.sendPhoneCallEvents(description: "Incoming|\(from)|\(callInvite.to)|Incoming\(formatCustomParams(params: callInvite.customParameters))", isError: false)
         self.sendPhoneCallEvents(description: "Ringing|\(from)|\(callInvite.to)|Incoming\(formatCustomParams(params: callInvite.customParameters))", isError: false)
         reportIncomingCall(from: from, uuid: callInvite.uuid)
         self.callInvite = callInvite

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -896,7 +896,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
 
         self.performVoiceCall(uuid: action.callUUID, client: "") { (success) in
             if (success) {
-                self.sendPhoneCallEvents(description: "LOG|provider:performAnswerVoiceCall() successful", isError: false)
+                self.sendPhoneCallEvents(description: "LOG|provider:performVoiceCall() successful", isError: false)
                 provider.reportOutgoingCall(with: action.callUUID, connectedAt: Date())
             } else {
                 self.sendPhoneCallEvents(description: "LOG|provider:performVoiceCall() failed", isError: false)

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -136,8 +136,16 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
                 }
             }
         } else if flutterCall.method == "makeCall" {
-            guard let callTo = arguments["To"] as? String else {return}
-            guard let callFrom = arguments["From"] as? String else {return}
+            // makeCall requires To/From; fail the call rather than silently returning,
+            // which would leave the awaiting Dart Future hanging forever.
+            guard let callTo = arguments["To"] as? String else {
+                result(FlutterError(code: "MALFORMED_ARGUMENTS", message: "No 'To' argument provided or invalid type", details: nil))
+                return
+            }
+            guard let callFrom = arguments["From"] as? String else {
+                result(FlutterError(code: "MALFORMED_ARGUMENTS", message: "No 'From' argument provided or invalid type", details: nil))
+                return
+            }
             self.callArgs = arguments
             self.callOutgoing = true
             if let accessToken = arguments["accessToken"] as? String{

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -6,7 +6,7 @@ import TwilioVoice
 import CallKit
 import UserNotifications
 
-public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHandler, PKPushRegistryDelegate, NotificationDelegate, CallDelegate, AVAudioPlayerDelegate, CXProviderDelegate, CXCallObserverDelegate {
+public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHandler, PKPushRegistryDelegate, NotificationDelegate, CallDelegate, AVAudioPlayerDelegate, CXProviderDelegate {
     let callObserver = CXCallObserver()
     
     final let defaultCallKitIcon = "callkit_icon"
@@ -41,12 +41,17 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
     var callKitCompletionCallback: ((Bool)->Swift.Void?)? = nil
     var audioDevice: DefaultAudioDevice = DefaultAudioDevice()
     
+    private func hasOtherCalls(besides uuid: UUID) -> Bool {
+        let ownUUIDs: [UUID] = [self.call?.uuid, self.callInvite?.uuid].compactMap { $0 }
+        return callObserver.calls.contains { c in
+            c.uuid != uuid && ownUUIDs.contains(c.uuid)
+        }
+    }
+    
     var callKitProvider: CXProvider
     var callKitCallController: CXCallController
     var userInitiatedDisconnect: Bool = false
     var callOutgoing: Bool = false
-    
-    private var activeCalls: [UUID: CXCall] = [:]
     
     static var appName: String {
         get {
@@ -71,7 +76,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         
         //super.init(coder: aDecoder)
         super.init()
-        callObserver.setDelegate(self, queue: DispatchQueue.main)
+
         
         callKitProvider.setDelegate(self, queue: nil)
         _ = updateCallKitIcon(icon: defaultIcon)
@@ -640,20 +645,9 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         }
     }
 
-    // MARK: CXCallObserverDelegate
-    public func callObserver(_ callObserver: CXCallObserver, callChanged call: CXCall) {
-        let uuid = call.uuid
-
-        if call.hasEnded {
-            activeCalls.removeValue(forKey: uuid) // Remove ended calls
-        } else {
-            activeCalls[uuid] = call // Add or update call
-        }
-    }
-    
-    // Check if a call with a given UUID exists
+    // MARK: CallKit call queries
     func isCallActive(uuid: UUID) -> Bool {
-        return activeCalls[uuid] != nil
+        return callObserver.calls.contains { $0.uuid == uuid && !$0.hasEnded }
     }
     
     func incomingPushHandled() {

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -80,16 +80,6 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         voipRegistry.desiredPushTypes = Set([PKPushType.voIP])
         
         UNUserNotificationCenter.current().delegate = self
-
-        let appDelegate = UIApplication.shared.delegate
-        guard let controller = appDelegate?.window??.rootViewController as? FlutterViewController else {
-            fatalError("rootViewController is not type FlutterViewController")
-        }
-        let registrar = controller.registrar(forPlugin: "twilio_voice")
-        if let unwrappedRegistrar = registrar {
-            let eventChannel = FlutterEventChannel(name: "twilio_voice/events", binaryMessenger: unwrappedRegistrar.messenger())
-            eventChannel.setStreamHandler(self)
-        }
     }
     
     

--- a/lib/_internal/platform_interface/shared_platform_interface.dart
+++ b/lib/_internal/platform_interface/shared_platform_interface.dart
@@ -19,8 +19,13 @@ abstract class SharedPlatformInterface extends PlatformInterface {
   EventChannel get eventChannel => _eventChannel;
   final EventChannel _eventChannel = const EventChannel(kEventChannelName);
 
+  /// Static so every subclass instance shares one event bus: on web, TwilioVoiceWeb's
+  /// [callEventsListener] subscribes to this stream while its separate Call instance
+  /// emits call-lifecycle events (Call Ended, Mute, ...) via [logLocalEvent]. With a
+  /// per-instance controller those events would go to an unsubscribed controller and
+  /// silently vanish.
   // ignore: close_sinks
-  StreamController<String>? _callEventsController;
+  static StreamController<String>? _callEventsController;
   StreamController<String> get callEventsController {
     _callEventsController ??= StreamController<String>.broadcast();
     return _callEventsController!;

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -352,16 +352,20 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
     }
   }
 
+  final _deviceListenerWrappers = <Function, Function>{};
+
+  Function _wrapDeviceListener(Function handler) => _deviceListenerWrappers[handler] ??= js.allowInterop(handler);
+
   /// Attach event listeners to [twilio_js.Device]
   /// See [twilio_js.Device.addListener](https://www.twilio.com/docs/voice/sdks/javascript/twiliodevice#deviceaddlistenereventname-listener)
   void _attachDeviceListeners(twilio_js.Device device) {
     // ignore: unnecessary_null_comparison
     assert(device != null, "Device cannot be null");
-    device.addListener("registered", js.allowInterop(_onDeviceRegistered));
-    device.addListener("unregistered", js.allowInterop(_onDeviceUnregistered));
-    device.addListener("error", js.allowInterop(_onDeviceError));
-    device.addListener("incoming", js.allowInterop(_onDeviceIncoming));
-    device.addListener("tokenWillExpire", js.allowInterop(_onTokenWillExpire));
+    device.addListener("registered", _wrapDeviceListener(_onDeviceRegistered));
+    device.addListener("unregistered", _wrapDeviceListener(_onDeviceUnregistered));
+    device.addListener("error", _wrapDeviceListener(_onDeviceError));
+    device.addListener("incoming", _wrapDeviceListener(_onDeviceIncoming));
+    device.addListener("tokenWillExpire", _wrapDeviceListener(_onTokenWillExpire));
   }
 
   /// Detach event listeners to [twilio_js.Device]
@@ -369,11 +373,11 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
   void _detachDeviceListeners(twilio_js.Device device) {
     // ignore: unnecessary_null_comparison
     assert(device != null, "Device cannot be null");
-    device.removeListener("registered", js.allowInterop(_onDeviceRegistered));
-    device.removeListener("unregistered", js.allowInterop(_onDeviceUnregistered));
-    device.removeListener("error", js.allowInterop(_onDeviceError));
-    device.removeListener("incoming", js.allowInterop(_onDeviceIncoming));
-    device.removeListener("tokenWillExpire", js.allowInterop(_onTokenWillExpire));
+    device.removeListener("registered", _wrapDeviceListener(_onDeviceRegistered));
+    device.removeListener("unregistered", _wrapDeviceListener(_onDeviceUnregistered));
+    device.removeListener("error", _wrapDeviceListener(_onDeviceError));
+    device.removeListener("incoming", _wrapDeviceListener(_onDeviceIncoming));
+    device.removeListener("tokenWillExpire", _wrapDeviceListener(_onTokenWillExpire));
   }
 
   /// On device registered and ready to make/receive calls via [twilio_js.Device.addListener] and [twilio_js.TwilioDeviceEvents.registered]
@@ -791,20 +795,24 @@ class Call extends MethodChannelTwilioCall {
     return true;
   }
 
+  final _callListenerWrappers = <Function, Function>{};
+
+  Function _wrapCallListener(Function handler) => _callListenerWrappers[handler] ??= js.allowInterop(handler);
+
   /// Attach event listeners to the active call
   /// See [twilio_js.Call.addListener]
   void _attachCallEventListeners(twilio_js.Call call) {
     // ignore: unnecessary_null_comparison
     assert(call != null, "Call cannot be null");
-    call.addListener("ringing", js.allowInterop(_onCallRinging));
-    call.addListener("accept", js.allowInterop(_onCallAccept));
-    call.addListener("disconnect", js.allowInterop(_onCallDisconnect));
-    call.addListener("cancel", js.allowInterop(_onCallCancel));
-    call.addListener("reject", js.allowInterop(_onCallReject));
-    call.addListener("error", js.allowInterop(_onCallError));
-    call.addListener("reconnecting", js.allowInterop(_onCallReconnecting));
-    call.addListener("reconnected", js.allowInterop(_onCallReconnected));
-    call.addListener("log", js.allowInterop(_onLogEvent));
+    call.addListener("ringing", _wrapCallListener(_onCallRinging));
+    call.addListener("accept", _wrapCallListener(_onCallAccept));
+    call.addListener("disconnect", _wrapCallListener(_onCallDisconnect));
+    call.addListener("cancel", _wrapCallListener(_onCallCancel));
+    call.addListener("reject", _wrapCallListener(_onCallReject));
+    call.addListener("error", _wrapCallListener(_onCallError));
+    call.addListener("reconnecting", _wrapCallListener(_onCallReconnecting));
+    call.addListener("reconnected", _wrapCallListener(_onCallReconnected));
+    call.addListener("log", _wrapCallListener(_onLogEvent));
   }
 
   /// Detach event listeners to the active call
@@ -813,15 +821,15 @@ class Call extends MethodChannelTwilioCall {
   void _detachCallEventListeners(twilio_js.Call call) {
     // ignore: unnecessary_null_comparison
     assert(call != null, "Call cannot be null");
-    call.removeListener("ringing", js.allowInterop(_onCallRinging));
-    call.removeListener("accept", js.allowInterop(_onCallAccept));
-    call.removeListener("disconnect", js.allowInterop(_onCallDisconnect));
-    call.removeListener("cancel", js.allowInterop(_onCallCancel));
-    call.removeListener("reject", js.allowInterop(_onCallReject));
-    call.removeListener("error", js.allowInterop(_onCallError));
-    call.removeListener("reconnecting", js.allowInterop(_onCallReconnecting));
-    call.removeListener("reconnected", js.allowInterop(_onCallReconnected));
-    call.removeListener("log", js.allowInterop(_onLogEvent));
+    call.removeListener("ringing", _wrapCallListener(_onCallRinging));
+    call.removeListener("accept", _wrapCallListener(_onCallAccept));
+    call.removeListener("disconnect", _wrapCallListener(_onCallDisconnect));
+    call.removeListener("cancel", _wrapCallListener(_onCallCancel));
+    call.removeListener("reject", _wrapCallListener(_onCallReject));
+    call.removeListener("error", _wrapCallListener(_onCallError));
+    call.removeListener("reconnecting", _wrapCallListener(_onCallReconnecting));
+    call.removeListener("reconnected", _wrapCallListener(_onCallReconnected));
+    call.removeListener("log", _wrapCallListener(_onLogEvent));
   }
 
   void _onLogEvent(String status) {

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -6,7 +6,7 @@ import 'dart:developer';
 // ignore: deprecated_member_use
 import 'dart:html' as html;
 
-import 'package:flutter/foundation.dart';
+// import 'package:flutter/foundation.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
 // Added as temporary measure till sky_engine includes js_util (allowInterop())

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -597,10 +597,12 @@ class Call extends MethodChannelTwilioCall {
   /// Toggle mute on/off. Returns true if successful, false otherwise.
   @override
   Future<bool?> toggleMute(bool isMuted) async {
-    logLocalEvent(isMuted ? "Mute" : "Unmute", prefix: "");
-    if (_jsCall != null) {
-      _jsCall!.mute(isMuted);
+    final jsCall = _jsCall;
+    if (jsCall == null) {
+      return false;
     }
+    jsCall.mute(isMuted);
+    logLocalEvent(isMuted ? "Mute" : "Unmute", prefix: "");
 
     final sid = _getSid();
     if(sid != null) {
@@ -909,13 +911,14 @@ class Call extends MethodChannelTwilioCall {
   /// - calling [disconnect] on an active call before recipient has answered
   /// Documentation: https://www.twilio.com/docs/voice/sdks/javascript/twiliocall#cancel-event
   void _onCallCancel() {
+    final jsCall = _jsCall;
+    if (jsCall == null) {
+      return;
+    }
     // notify SW to cancel notification
     final callStatus = getCallStatus(jsCall);
-    final callStatus = getCallStatus(_jsCall!);
-    if (_jsCall != null) {
-      _detachCallEventListeners(_jsCall!);
-      nativeCall = null;
-    }
+    _detachCallEventListeners(jsCall);
+    nativeCall = null;
     logLocalEvent("Call Ended", prefix: "");
 
     // reject incoming call that is both outbound ringing or inbound pending
@@ -998,16 +1001,23 @@ class Call extends MethodChannelTwilioCall {
     }
   }
 
-  Future<void> _addAttribute(String uuid, CKCallAttributes attribute) {
-    final call = webCallkit.getCall(uuid)!;
+  Future<void> _addAttribute(String uuid, CKCallAttributes attribute) async {
+    // web_callkit may not be tracking this call (e.g. notification was never shown).
+    final call = webCallkit.getCall(uuid);
+    if (call == null) {
+      return;
+    }
     final attrs = call.attributes..add(attribute);
-    return webCallkit.updateCallAttributes(uuid, attributes: attrs);
+    await webCallkit.updateCallAttributes(uuid, attributes: attrs);
   }
 
-  Future<void> _removeAttribute(String uuid, CKCallAttributes attribute) {
-    final call = webCallkit.getCall(uuid)!;
+  Future<void> _removeAttribute(String uuid, CKCallAttributes attribute) async {
+    final call = webCallkit.getCall(uuid);
+    if (call == null) {
+      return;
+    }
     final attrs = call.attributes..remove(attribute);
-    return webCallkit.updateCallAttributes(uuid, attributes: attrs);
+    await webCallkit.updateCallAttributes(uuid, attributes: attrs);
   }
 }
 

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -219,10 +219,8 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
       if (perm.state == "granted") {
         return true;
       } else if (perm.state == "prompt") {
-        logLocalEvent("RequestMicrophoneAccess");
         return false;
       } else {
-        logLocalEvent("Microphone permission denied", prefix: "");
         return false;
       }
     } catch (e) {

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -451,7 +451,10 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
     await webCallkit.requestPermissions();
 
     final params = getCallParams(call);
-    final callSid = params["CallSid"] as String;
+    final callSid = params["CallSid"];
+    if (callSid == null) {
+      return;
+    }
     final title = _resolveCallerName(params);
     // todo(cybex-dev): add support for custom image in web callkit.
     final imageUrl = _resolveImageUrl(params);
@@ -598,8 +601,11 @@ class Call extends MethodChannelTwilioCall {
     if (_jsCall != null) {
       _jsCall!.mute(isMuted);
     }
+
     final sid = _getSid();
-    await _toggleAttribute(isMuted, sid!, CKCallAttributes.mute);
+    if(sid != null) {
+      await _toggleAttribute(isMuted, sid, CKCallAttributes.mute);
+    }
     return isMuted;
   }
 
@@ -623,9 +629,12 @@ class Call extends MethodChannelTwilioCall {
   Future<bool?> holdCall({bool holdCall = true}) async {
     // logLocalEvent(holdCall ? "Unhold" : "Hold", prefix: "");
     // return Future.value(false);
-    logLocalEvent("Unhold");
     final sid = _getSid();
-    await _toggleAttribute(false, sid!, CKCallAttributes.hold);
+    if (sid == null) {
+      return false;
+    }
+    logLocalEvent("Unhold");
+    await _toggleAttribute(false, sid, CKCallAttributes.hold);
     return Future.value(false);
   }
 
@@ -664,7 +673,9 @@ class Call extends MethodChannelTwilioCall {
 
       // notify SW to cancel notification
       final callSid = _getSid();
-      webCallkit.updateCallStatus(callSid!, callStatus: CKCallState.active);
+      if (callSid != null) {
+        webCallkit.updateCallStatus(callSid, callStatus: CKCallState.active);
+      }
 
       return true;
     }
@@ -849,7 +860,9 @@ class Call extends MethodChannelTwilioCall {
         prefix: "",
       );
       final sid = _getSid();
-      webCallkit.reportOutgoingCall(uuid: sid!, handle: to, metadata: params, data: params);
+      if (sid != null) {
+        webCallkit.reportOutgoingCall(uuid: sid, handle: to, metadata: params, data: params);
+      }
     }
   }
 
@@ -897,7 +910,7 @@ class Call extends MethodChannelTwilioCall {
   /// Documentation: https://www.twilio.com/docs/voice/sdks/javascript/twiliocall#cancel-event
   void _onCallCancel() {
     // notify SW to cancel notification
-    final callSid = _getSid();
+    final callStatus = getCallStatus(jsCall);
     final callStatus = getCallStatus(_jsCall!);
     if (_jsCall != null) {
       _detachCallEventListeners(_jsCall!);
@@ -907,11 +920,15 @@ class Call extends MethodChannelTwilioCall {
 
     // reject incoming call that is both outbound ringing or inbound pending
     // TODO(cybex-dev): check call status for call disconnects
+    final callSid = _getSid();
+    if(callSid == null) {
+      return;
+    }
     if (callStatus == CallStatus.ringing || callStatus == CallStatus.pending || callStatus == CallStatus.closed) {
       logLocalEvent("Missed Call", prefix: "");
-      webCallkit.reportCallDisconnected(callSid!, response: CKDisconnectResponse.missed);
+      webCallkit.reportCallDisconnected(callSid, response: CKDisconnectResponse.missed);
     } else {
-      webCallkit.reportCallDisconnected(callSid!, response: CKDisconnectResponse.local);
+      webCallkit.reportCallDisconnected(callSid, response: CKDisconnectResponse.local);
     }
   }
 
@@ -924,7 +941,9 @@ class Call extends MethodChannelTwilioCall {
       nativeCall = null;
     }
     logLocalEvent("Call Rejected");
-    webCallkit.reportCallDisconnected(callSid!, response: CKDisconnectResponse.rejected);
+    if (callSid != null) {
+      webCallkit.reportCallDisconnected(callSid, response: CKDisconnectResponse.rejected);
+    }
   }
 
   /// On reject (inbound) call
@@ -941,25 +960,29 @@ class Call extends MethodChannelTwilioCall {
     final params = getCallParams(call);
     final from = params["From"] ?? "";
     final to = params["To"] ?? "";
-    final callSid = params["CallSid"] as String;
+    final callSid = params["CallSid"];
     logLocalEventEntries(["Connected", from, to, direction], prefix: "");
-    webCallkit.updateCallStatus(callSid, callStatus: CKCallState.active);
+    if (callSid != null) {
+      webCallkit.updateCallStatus(callSid, callStatus: CKCallState.active);
+    }
   }
 
   /// On active call reconnecting to Twilio network
   void _onCallReconnecting(dynamic twilioError) {
     logLocalEvent("Reconnecting");
-    final params = getCallParams(_jsCall!);
-    final callSid = params["CallSid"] as String;
-    webCallkit.updateCallStatus(callSid, callStatus: CKCallState.reconnecting);
+    final callSid = _getSid();
+    if (callSid != null) {
+      webCallkit.updateCallStatus(callSid, callStatus: CKCallState.reconnecting);
+    }
   }
 
   /// On active call reconnecting to Twilio network
   void _onCallReconnected() {
     logLocalEvent("Reconnected");
-    final params = getCallParams(_jsCall!);
-    final callSid = params["CallSid"] as String;
-    webCallkit.updateCallStatus(callSid, callStatus: CKCallState.active);
+    final callSid = _getSid();
+    if (callSid != null) {
+      webCallkit.updateCallStatus(callSid, callStatus: CKCallState.active);
+    }
   }
 
   CallStatus getCallStatus(twilio_js.Call call) {

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -590,7 +590,6 @@ class Call extends MethodChannelTwilioCall {
   /// Not currently implemented for web
   @override
   Future<bool?> toggleSpeaker(bool speakerIsOn) async {
-    logLocalEvent(speakerIsOn ? "Speaker On" : "Speaker Off", prefix: "");
     return Future.value(false);
   }
 

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -669,7 +669,7 @@ class Call extends MethodChannelTwilioCall {
       final from = params["From"] ?? "";
       final to = params["To"] ?? "";
       logLocalEventEntries(
-        ["Answer", from, to, jsonEncode(params)],
+        ["Answer", from, to, "Incoming", jsonEncode(params)],
         prefix: "",
       );
 
@@ -879,6 +879,7 @@ class Call extends MethodChannelTwilioCall {
         "Answer",
         from,
         to,
+        "Incoming",
         jsonEncode(params),
       ], prefix: "");
 

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -35,52 +35,6 @@ import 'method_channel/twilio_call_method_channel.dart';
 import 'method_channel/twilio_voice_method_channel.dart';
 import 'utils.dart';
 
-class Logger {
-  // ignore: close_sinks
-  static StreamController<String>? _callEventsController;
-
-  static StreamController<String> get callEventsController {
-    _callEventsController ??= StreamController<String>.broadcast();
-    return _callEventsController!;
-  }
-
-  static Stream<String> get callEventsStream => callEventsController.stream;
-
-  /// Logs event to EventChannel, but uses [List.join] with [separator] to join [prefix] and [description].
-  /// This is used to send events to the EventChannel for integration into existing communication flow.
-  /// The event will be sent as a String with the following format:
-  /// - (if prefix is not empty): "prefix|description", where '|' is separator
-  /// - (if prefix is empty): "description"
-  static void logLocalEventEntries(List<String> entries, {String prefix = "LOG", String separator = "|"}) {
-    logLocalEvent(entries.join(separator), prefix: prefix, separator: separator);
-  }
-
-  /// Logs event to EventChannel.
-  /// This is used to send events to the EventChannel for integration into existing communication flow.
-  /// The event will be sent as a String with the following format:
-  /// - (if prefix is not empty): "prefix|description", where '|' is separator
-  /// - (if prefix is empty): "description"
-  static void logLocalEvent(String description, {String prefix = "LOG", String separator = "|"}) async {
-    if (!kIsWeb) {
-      throw UnimplementedError("Use eventChannel() via sendPhoneEvents on platform implementation");
-    }
-    // eventChannel.binaryMessenger.handlePlatformMessage(
-    //   _kEventChannelName,
-    //   const StandardMethodCodec().encodeSuccessEnvelope(description),
-    //   (ByteData? data) {},
-    // );
-    String message = "";
-    if (prefix.isEmpty) {
-      message = description;
-    } else {
-      message = "$prefix$separator$description";
-    }
-
-    // Send events to EventChannel for integration into existing communication flow
-    callEventsController.add(message);
-  }
-}
-
 /// The web implementation of [TwilioVoicePlatform].
 class TwilioVoiceWeb extends MethodChannelTwilioVoice {
   
@@ -180,7 +134,7 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
 
   @override
   Stream<CallEvent> get callEventsListener {
-    _callEventsListener ??= Logger.callEventsStream.map(parseCallEvent);
+    _callEventsListener ??= callEventsStream.map(parseCallEvent);
     return _callEventsListener!;
   }
 
@@ -194,7 +148,7 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
   /// See [LocalStorageWeb.saveDefaultCallerName]
   @override
   Future<bool?> setDefaultCallerName(String callerName) async {
-    Logger.logLocalEvent("defaultCaller is $callerName");
+    logLocalEvent("defaultCaller is $callerName");
     _localStorage.saveDefaultCallerName(callerName);
     return true;
   }
@@ -203,7 +157,7 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
   /// See [LocalStorageWeb.removeRegisteredClient]
   @override
   Future<bool?> unregisterClient(String clientId) async {
-    Logger.logLocalEvent("Unregistering$clientId");
+    logLocalEvent("Unregistering$clientId");
     _localStorage.removeRegisteredClient(clientId);
     return true;
   }
@@ -212,7 +166,7 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
   /// See [LocalStorageWeb.addRegisteredClient]
   @override
   Future<bool?> registerClient(String clientId, String clientName) async {
-    Logger.logLocalEvent("Registering client $clientId:$clientName");
+    logLocalEvent("Registering client $clientId:$clientName");
     _localStorage.addRegisteredClient(clientId, clientName);
     return true;
   }
@@ -223,7 +177,7 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
   /// This is a 'hack' to acquire media permissions. The permissions API is not supported in all browsers.
   @override
   Future<bool?> requestMicAccess() async {
-    Logger.logLocalEvent("requesting mic permission");
+    logLocalEvent("requesting mic permission");
     try {
       final isSafariOrFirefox = RegExp(r'^((?!chrome|android).)*safari|firefox', caseSensitive: false).hasMatch(_webNavigatorDelegate.userAgent);
 
@@ -255,7 +209,7 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
   /// Documentation: https://developer.mozilla.org/en-US/docs/Web/API/Permissions/query
   @override
   Future<bool> hasMicAccess() async {
-    Logger.logLocalEvent("checkPermissionForMicrophone");
+    logLocalEvent("checkPermissionForMicrophone");
     try {
       final perm = await _webPermissionsDelegate?.query({"name": "microphone"});
       if (perm == null) {
@@ -265,10 +219,10 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
       if (perm.state == "granted") {
         return true;
       } else if (perm.state == "prompt") {
-        Logger.logLocalEvent("RequestMicrophoneAccess");
+        logLocalEvent("RequestMicrophoneAccess");
         return false;
       } else {
-        Logger.logLocalEvent("Microphone permission denied", prefix: "");
+        logLocalEvent("Microphone permission denied", prefix: "");
         return false;
       }
     } catch (e) {
@@ -433,11 +387,11 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
   // /// Documentation: https://www.twilio.com/docs/voice/sdks/javascript/twiliodevice#registered-event
   // Function _onDeviceRegistered() {
   //   // final _f = (twilioJs.Device device) {
-  //   //   Logger.logLocalEvent("Device registered for callInvites", prefix: "");
+  //   //   logLocalEvent("Device registered for callInvites", prefix: "");
   //   // };
   //   // return allowInterop(_f);
   //   return allowInterop((twilioJs.Device device) {
-  //     Logger.logLocalEvent("Device registered for callInvites", prefix: "");
+  //     logLocalEvent("Device registered for callInvites", prefix: "");
   //   });
   // }
 
@@ -464,11 +418,11 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
     final params = getCallParams(call);
     final from = params["From"] ?? "";
     final to = params["To"] ?? "";
-    Logger.logLocalEventEntries(
+    logLocalEventEntries(
       ["Incoming", from, to, "Incoming", jsonEncode(params)],
       prefix: "",
     );
-    Logger.logLocalEventEntries(
+    logLocalEventEntries(
       ["Ringing", from, to, "Incoming", jsonEncode(params)],
       prefix: "",
     );
@@ -631,14 +585,14 @@ class Call extends MethodChannelTwilioCall {
   /// Not currently implemented for web
   @override
   Future<bool?> toggleSpeaker(bool speakerIsOn) async {
-    Logger.logLocalEvent(speakerIsOn ? "Speaker On" : "Speaker Off", prefix: "");
+    logLocalEvent(speakerIsOn ? "Speaker On" : "Speaker Off", prefix: "");
     return Future.value(false);
   }
 
   /// Toggle mute on/off. Returns true if successful, false otherwise.
   @override
   Future<bool?> toggleMute(bool isMuted) async {
-    Logger.logLocalEvent(isMuted ? "Mute" : "Unmute", prefix: "");
+    logLocalEvent(isMuted ? "Mute" : "Unmute", prefix: "");
     if (_jsCall != null) {
       _jsCall!.mute(isMuted);
     }
@@ -665,9 +619,9 @@ class Call extends MethodChannelTwilioCall {
   /// TODO(cybex-dev) - implement call holding feature in [twilio-voice.js](https://github.com/twilio/twilio-voice.js) for use in twilio_voice_web
   @override
   Future<bool?> holdCall({bool holdCall = true}) async {
-    // Logger.logLocalEvent(holdCall ? "Unhold" : "Hold", prefix: "");
+    // logLocalEvent(holdCall ? "Unhold" : "Hold", prefix: "");
     // return Future.value(false);
-    Logger.logLocalEvent("Unhold");
+    logLocalEvent("Unhold");
     final sid = _getSid();
     await _toggleAttribute(false, sid!, CKCallAttributes.hold);
     return Future.value(false);
@@ -701,7 +655,7 @@ class Call extends MethodChannelTwilioCall {
       final params = getCallParams(_jsCall!);
       final from = params["From"] ?? "";
       final to = params["To"] ?? "";
-      Logger.logLocalEventEntries(
+      logLocalEventEntries(
         ["Answer", from, to, jsonEncode(params)],
         prefix: "",
       );
@@ -780,7 +734,7 @@ class Call extends MethodChannelTwilioCall {
     assert(!options.keys.contains("From"), "'from' cannot be passed in 'extraOptions'");
     assert(!options.keys.contains("To"), "'to' cannot be passed in 'extraOptions'");
 
-    Logger.logLocalEvent("Making new call");
+    logLocalEvent("Making new call");
     // handle parameters
     final params = <String, String>{
       "From": from,
@@ -800,7 +754,7 @@ class Call extends MethodChannelTwilioCall {
       nativeCall = await js_util.promiseToFuture(promise);
 
       _attachCallEventListeners(_jsCall!);
-      Logger.logLocalEvent("Call placed");
+      logLocalEvent("Call placed");
     } catch (e) {
       printDebug("Failed to place call: $e");
       return false;
@@ -816,7 +770,7 @@ class Call extends MethodChannelTwilioCall {
   Future<bool?> connect({Map<String, dynamic>? extraOptions}) async {
     assert(device != null, "Twilio device is null, make sure you have initialized the device first by calling [ setTokens({required String accessToken, String? deviceToken}) ] ");
 
-    Logger.logLocalEvent("Making new call with Connect");
+    logLocalEvent("Making new call with Connect");
     // handle parameters
     final params = <String, String>{};
     extraOptions?.forEach((key, value) {
@@ -884,7 +838,7 @@ class Call extends MethodChannelTwilioCall {
       final from = params["From"] ?? "";
       final to = params["To"] ?? "";
       final direction = _jsCall!.direction == "INCOMING" ? "Incoming" : "Outgoing";
-      Logger.logLocalEventEntries(
+      logLocalEventEntries(
         ["Ringing", from, to, direction],
         prefix: "",
       );
@@ -900,7 +854,7 @@ class Call extends MethodChannelTwilioCall {
       final params = getCallParams(call);
       final from = params["From"] ?? "";
       final to = params["To"] ?? "";
-      Logger.logLocalEventEntries([
+      logLocalEventEntries([
         "Answer",
         from,
         to,
@@ -918,7 +872,7 @@ class Call extends MethodChannelTwilioCall {
     final status = getCallStatus(call);
     _detachCallEventListeners(call);
     if (status == CallStatus.closed && _jsCall != null) {
-      Logger.logLocalEvent("Call Ended", prefix: "");
+      logLocalEvent("Call Ended", prefix: "");
     }
     nativeCall = null;
 
@@ -943,12 +897,12 @@ class Call extends MethodChannelTwilioCall {
       _detachCallEventListeners(_jsCall!);
       nativeCall = null;
     }
-    Logger.logLocalEvent("Call Ended", prefix: "");
+    logLocalEvent("Call Ended", prefix: "");
 
     // reject incoming call that is both outbound ringing or inbound pending
     // TODO(cybex-dev): check call status for call disconnects
     if (callStatus == CallStatus.ringing || callStatus == CallStatus.pending || callStatus == CallStatus.closed) {
-      Logger.logLocalEvent("Missed Call", prefix: "");
+      logLocalEvent("Missed Call", prefix: "");
       webCallkit.reportCallDisconnected(callSid!, response: CKDisconnectResponse.missed);
     } else {
       webCallkit.reportCallDisconnected(callSid!, response: CKDisconnectResponse.local);
@@ -963,14 +917,14 @@ class Call extends MethodChannelTwilioCall {
       _detachCallEventListeners(_jsCall!);
       nativeCall = null;
     }
-    Logger.logLocalEvent("Call Rejected");
+    logLocalEvent("Call Rejected");
     webCallkit.reportCallDisconnected(callSid!, response: CKDisconnectResponse.rejected);
   }
 
   /// On reject (inbound) call
   /// Documentation: https://www.twilio.com/docs/voice/sdks/javascript/twiliocall#error-event
   void _onCallError(twilio_js.TwilioError error) {
-    Logger.logLocalEvent("Call Error: ${error.code}, ${error.message}");
+    logLocalEvent("Call Error: ${error.code}, ${error.message}");
   }
 
   /// On active call connected to remote client
@@ -982,13 +936,13 @@ class Call extends MethodChannelTwilioCall {
     final from = params["From"] ?? "";
     final to = params["To"] ?? "";
     final callSid = params["CallSid"] as String;
-    Logger.logLocalEventEntries(["Connected", from, to, direction], prefix: "");
+    logLocalEventEntries(["Connected", from, to, direction], prefix: "");
     webCallkit.updateCallStatus(callSid, callStatus: CKCallState.active);
   }
 
   /// On active call reconnecting to Twilio network
   void _onCallReconnecting(dynamic twilioError) {
-    Logger.logLocalEvent("Reconnecting");
+    logLocalEvent("Reconnecting");
     final params = getCallParams(_jsCall!);
     final callSid = params["CallSid"] as String;
     webCallkit.updateCallStatus(callSid, callStatus: CKCallState.reconnecting);
@@ -996,7 +950,7 @@ class Call extends MethodChannelTwilioCall {
 
   /// On active call reconnecting to Twilio network
   void _onCallReconnected() {
-    Logger.logLocalEvent("Reconnected");
+    logLocalEvent("Reconnected");
     final params = getCallParams(_jsCall!);
     final callSid = params["CallSid"] as String;
     webCallkit.updateCallStatus(callSid, callStatus: CKCallState.active);

--- a/macos/Classes/JsInterop/Device/TVDeviceConnectOptions.swift
+++ b/macos/Classes/JsInterop/Device/TVDeviceConnectOptions.swift
@@ -7,8 +7,12 @@ public class TVDeviceConnectOptions: JSONArgumentSerializer {
     var params: [String: String] = [:]
 
     init(to: String?, from: String?, customParameters: [String:Any]) {
-        if(to != nil) params[Constants.PARAM_TO] = to
-        if(from != nil) params[Constants.PARAM_FROM] = from
+        if let to = to {
+            params[Constants.PARAM_TO] = to
+        }
+        if let from = from {
+            params[Constants.PARAM_FROM] = from
+        }
         let stringMap = customParameters.map({ (key, value) -> (String, String) in
             (key, String(describing: value))
         });

--- a/macos/Classes/TwilioVoicePlugin.swift
+++ b/macos/Classes/TwilioVoicePlugin.swift
@@ -241,7 +241,15 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
                     completionHandler(true)
                     return
                 }
+                // Neither a call nor an error: complete rather than leaving the Dart
+                // Future hanging.
+                completionHandler(false)
             }
+        } else {
+            // Device not initialized (setTokens not called): complete with failure
+            // rather than leaving the Dart Future hanging with no log.
+            logEvent(description: "Cannot place call: Twilio Device not initialized, call `setTokens` first")
+            completionHandler(false)
         }
     }
 

--- a/macos/Classes/TwilioVoicePlugin.swift
+++ b/macos/Classes/TwilioVoicePlugin.swift
@@ -599,8 +599,11 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
             }
             break
         case .connect:
-            guard let to = arguments[Constants.PARAM_TO] as? String?
-            guard let from = arguments[Constants.PARAM_FROM] as? String
+            // Raw connect: To/From are optional (aligned with the iOS implementation) -
+            // routing parameters travel in the remaining arguments and the TwiML
+            // application decides the destination.
+            let to = arguments[Constants.PARAM_TO] as? String
+            let from = arguments[Constants.PARAM_FROM] as? String
 
             var params: [String: Any] = [:]
             arguments.forEach { (key, value) in

--- a/macos/Classes/TwilioVoicePlugin.swift
+++ b/macos/Classes/TwilioVoicePlugin.swift
@@ -209,19 +209,25 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
     ///   - to: recipient
     ///   - extraOptions: extra options
     ///   - completionHandler: completion handler -> (Bool?)
-    private func place(from: String?, to: String?, extraOptions: [String: Any]?, completionHandler: @escaping OnCompletionValueHandler<Bool>) -> Void {
-        assert(from.isNotEmpty(), "\(Constants.PARAM_FROM) cannot be empty")
-        assert(to.isNotEmpty(), "\(Constants.PARAM_TO) cannot be empty")
+    private func place(from: String?, to: String?, extraOptions: [String: Any]?, connect: Bool = false, completionHandler: @escaping OnCompletionValueHandler<Bool>) -> Void {
+        // Raw connect() calls may omit To/From entirely (the TwiML app decides routing);
+        // only regular makeCall requires them. Mirrors the Android placeCall(connect:)
+        // contract: assert(connect || !isNullOrEmpty).
+        assert(connect || (from?.isNotEmpty() ?? false), "\(Constants.PARAM_FROM) cannot be empty")
+        assert(connect || (to?.isNotEmpty() ?? false), "\(Constants.PARAM_TO) cannot be empty")
 //        assert(extraOptions?.keys.contains(Constants.PARAM_FROM) ?? true, "\(Constants.PARAM_FROM) cannot be passed in extraOptions")
 //        assert(extraOptions?.keys.contains(Constants.PARAM_TO) ?? true, "\(Constants.PARAM_TO) cannot be passed in extraOptions")
 //        assert(twilioDevice != nil, "Twilio Device must be initialized before making calls")
 
         logEvent(description: "Making new call")
 
-        var params: [String: Any] = [
-            if(from != nil) Constants.PARAM_FROM: from,
-            if(to != nil) Constants.PARAM_TO: to,
-        ]
+        var params: [String: Any] = [:]
+        if let from = from {
+            params[Constants.PARAM_FROM] = from
+        }
+        if let to = to {
+            params[Constants.PARAM_TO] = to
+        }
         if let extraOptions = extraOptions {
             params.merge(extraOptions) { (_, new) in
                 new
@@ -620,7 +626,7 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
                 }
             }
 
-            place(from: from, to: to, extraOptions: params) { success in
+            place(from: from, to: to, extraOptions: params, connect: true) { success in
                 result(success ?? false)
             }
             break


### PR DESCRIPTION
# Description

This pull request significantly refactors call handling across all platforms, focusing on stability, compliance, and improved integration. It includes major updates for Android's Foreground Service, extensive enhancements for iOS CallKit integration, and refined FCM token management. A key change is the removal of the custom, client-side call holding implementation for Web and macOS, simplifying the API and reducing complexity. Additionally, the `connect()` method now offers more flexible `To`/`From` parameter handling.

## Android Improvements

*   Adds support for `FOREGROUND_SERVICE_TYPE_PHONE_CALL` to meet Android 14+ requirements for ongoing calls.
*   Dynamically refreshes Foreground Service types when microphone permission is granted mid-call.
*   Ensures permission request callbacks complete reliably, even on re-requests.
*   Improves handling of concurrent calls in `TVConnectionService` to prevent premature service termination.
*   Notifies the plugin of new FCM tokens via `LocalBroadcastManager` and re-registers them with Twilio, preventing silent loss of incoming calls.

## iOS Improvements

*   Integrates CallKit for `mute` and `hold` actions, keeping the system UI in sync with the Twilio call state.
*   Notifies CallKit of call failures to avoid orphan call states.
*   Uses the `DefaultAudioDevice` for improved audio routing and control with the Twilio SDK.
*   Adds an "Incoming" call event for unified platform behavior.
*   Handles push notifications more robustly, logging unhandled ones and correctly parsing system versions.
*   Sends hex-formatted device tokens to Dart and removes unnecessary logging on registration failure.
*   Stricter parameter validation for `makeCall` and more flexible `connect` arguments.

## Web & macOS Changes

*   **Removes the custom client-side call holding feature** that relied on the AudioProcessor API for Web and macOS. The `holdCall` method on these platforms now acts as a no-op, requiring developers to implement server-side holding if needed.
*   Cleans up unused JavaScript interop for audio processors and media streams.
*   Improves function caching and robustness for calls and devices in the web implementation.
*   Adds support for optional `From`/`To` parameters in raw `connect()` calls for macOS, mirroring Android behavior.
*   Fixes an issue in macOS where the future would hang when placing a call and an error occurred or if not registered with Twilio.

## General Improvements

*   Refactors internal event stream handling to use a static, class-wide controller for consistency.
*   Adds numerous null-check guards and refactors code for improved reliability and readability across the codebase.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Screenshots (if appropriate):