### PR TITLE
fix(ios): resolve rootViewController from connected UIWindowScene (fixes launch crash under UIScene lifecycle)

### DIFF
--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -79,8 +79,23 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         UNUserNotificationCenter.current().delegate = self
 
         let appDelegate = UIApplication.shared.delegate
-        guard let controller = appDelegate?.window??.rootViewController as? FlutterViewController else {
-            fatalError("rootViewController is not type FlutterViewController")
+        // UIScene lifecycle (modern Flutter template): appDelegate.window is nil
+        // because the window belongs to the scene. Resolve it from the connected
+        // scenes instead of force-crashing.
+        let resolvedWindow = (appDelegate?.window ?? nil)
+            ?? UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+                .first(where: { $0.isKeyWindow })
+            ?? UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+                .first
+        guard let controller = resolvedWindow?.rootViewController as? FlutterViewController else {
+            // rootVC not attached yet during registration; the method/event
+            // channels are also wired in register(with:), so skip the redundant
+            // init-time channel setup rather than crashing.
+            return
         }
         let registrar = controller.registrar(forPlugin: "twilio_voice")
         if let unwrappedRegistrar = registrar {


### PR DESCRIPTION
## Problem

On the modern Flutter iOS template (Flutter ≥ 3.35, which uses the **UIScene lifecycle** — a `SceneDelegate` extending `FlutterSceneDelegate` + a `UIApplicationSceneManifest`), `UIApplication.shared.delegate.window` is always `nil` because the window is owned by the scene, not the app delegate.

`SwiftTwilioVoicePlugin.init()` does:

```swift
let appDelegate = UIApplication.shared.delegate
guard let controller = appDelegate?.window??.rootViewController as? FlutterViewController else {
    fatalError("rootViewController is not type FlutterViewController")
}
```

Because `appDelegate.window` is `nil`, this `fatalError`s during plugin registration — **crashing the entire host app at launch**, before any Dart runs. Stack trace bottoms out at `SwiftTwilioVoicePlugin.init()` → `register(with:)` → `GeneratedPluginRegistrant` → `didInitializeImplicitFlutterEngine`.

## Fix

Resolve the window from `UIApplication.shared.connectedScenes` when the app delegate has no window, and — since the method/event channels are also wired in `register(with:)` — **degrade gracefully (`return`) instead of `fatalError`** if the root view controller isn't attached yet during registration.

No behavior change for classic (non-scene) apps: `appDelegate.window` is used first when present.

## Testing

Reproduced the launch crash on a Flutter 3.44.7 app using the UIScene template (iOS 26 simulator). With this change the host app launches normally and the plugin's channels work. Verified against tag `0.3.2+2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)