### PR TITLE
fix: unknown caller on call initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 * fix: [android] use app name as phone account label if not specified. 
 * fix: [android] buffer native log events until dart initialization completed and ready to receive events.
 * feat: [android] correctly show missed call honouring `showMissedCallNotifications` setting when app is backgrounded or terminated.
+* fix: [android] outgoing calls no longer show "Unknown" on the native call screen while connecting.
 * fix: [ios] changing `enableCallLogging` setting now correctly updates call logging behaviour for subsequent calls.
 * fix: [macos] `toggleBluetooth` now returns `Future` with correct value (though bluetooth not yet implemented).
 * fix: [ios] fix invalid Twilio VoIP payload crashing app

--- a/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
@@ -691,7 +691,11 @@ class TVConnectionService : ConnectionService() {
         connection.setOnCallDisconnected(onCallInitializingDisconnectedListener)
 //        connection.setOnCallEventListener(onEvent)
 
-        // Setup connection UI parameters
+        // Set callername on initialization - if present.
+        to?.takeIf { it.isNotEmpty() }?.let {
+            connection.setAddress(Uri.fromParts(PhoneAccount.SCHEME_TEL, it, null), TelecomManager.PRESENTATION_ALLOWED)
+            connection.setCallerDisplayName(it, TelecomManager.PRESENTATION_ALLOWED)
+        }
         connection.setInitializing()
 
         // Apply extras


### PR DESCRIPTION
This pull request addresses an issue where outgoing calls on Android were displaying "Unknown" as the caller name on the native call screen while connecting. The update ensures that the correct caller name is shown if available, improving the user experience for outgoing calls.

Android outgoing call display improvements:

* Outgoing calls now use the intended caller name as the display name on the native call screen while connecting, instead of showing "Unknown". (`TVConnectionService.kt`)
* Updated the changelog to document the fix for outgoing calls showing "Unknown" on the native call screen. (`CHANGELOG.md`)