### PR TITLE
bugfix: EVENT_CONNECT_FAILURE

### DIFF
--- a/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
@@ -1972,6 +1972,7 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
                     return
                 }
                 logEvent("Call Error: ${code}, $message");
+                logEvent("", "Call Ended")
             }
 
             TVNativeCallEvents.EVENT_RECONNECTING -> {


### PR DESCRIPTION
When you dial an invalid phone number there will be an EVENT_CONNECT_FAILURE. 
There currently is no event propagated to end the call.