### PR TITLE
feat: add `allowIncomingWhileBusy` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 * fix: [ios] fix invalid Twilio VoIP payload crashing app
 * fix: [ios] fix plugin in limbo when new incoming call fails to register
 * fix: [macOS,web] add missing `updateCallKitIcon` native implementation to unify platform behaviour contract.
+* feat: add `setAllowIncomingWhileBusy(allow: bool)` to control whether multiple incoming call invites are allowed (i.e. handle 2 or more calls at once). All platforms default to true;
 * Feat: update example.
 * Docs: update CHANGELOG
 

--- a/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
@@ -996,6 +996,41 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
                 }
             }
 
+            TVMethodChannels.SET_ALLOW_INCOMING_WHILE_BUSY -> {
+                val allow = call.argument<Boolean>("allow") ?: run {
+                    result.error(
+                        FlutterErrorCodes.MALFORMED_ARGUMENTS,
+                        "No 'allow' provided or invalid type",
+                        null
+                    )
+                    return@onMethodCall
+                }
+
+                storage?.let {
+                    Log.d(TAG, "onMethodCall: allowIncomingWhileBusy is $allow")
+                    it.allowIncomingWhileBusy = allow
+                    result.success(true)
+                } ?: run {
+                    Log.e(
+                        TAG,
+                        "Storage is null, cannot set allowIncomingWhileBusy. Has Storage been initialized?"
+                    )
+                    result.success(false)
+                }
+            }
+
+            TVMethodChannels.GET_ALLOW_INCOMING_WHILE_BUSY -> {
+                storage?.let {
+                    result.success(it.allowIncomingWhileBusy)
+                } ?: run {
+                    Log.e(
+                        TAG,
+                        "Storage is null, cannot get allowIncomingWhileBusy. Has Storage been initialized?"
+                    )
+                    result.success(true)
+                }
+            }
+
             TVMethodChannels.IS_REJECTING_CALL_ON_NO_PERMISSIONS -> {
                 storage?.let {
                     result.success(it.rejectOnNoPermissions)

--- a/android/src/main/kotlin/com/twilio/twilio_voice/fcm/TwilioVoiceFcm.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/fcm/TwilioVoiceFcm.kt
@@ -93,10 +93,34 @@ internal class VoiceMessageListener(private val context: Context) : MessageListe
                     "Parameters: ${callInvite.customParameters.entries.joinToString { "${it.key}:${it.value}" }},\n\t" +
                     "}"
         )
+        val storage = StorageImpl(context)
+
+        // Reject the invite when already on a call and the app opted out of concurrent calls.
+        // Deliberately uses TVConnectionService.hasActiveCalls() - the plugin's *own* connections -
+        // rather than TelecomManager.isOnCall(), which reports true for any call on the device
+        // (including unrelated SIM/carrier calls).
+        if (!storage.allowIncomingWhileBusy && TVConnectionService.hasActiveCalls()) {
+            Log.i(TAG, "onCallInvite: already on a call and allowIncomingWhileBusy is false, rejecting\nSID: ${callInvite.callSid}")
+
+            // Notify Flutter the call was ignored, mirroring the no-permissions path.
+            Intent(context, TVBroadcastReceiver::class.java).apply {
+                action = TVBroadcastReceiver.ACTION_INCOMING_CALL_IGNORED
+                putExtra(
+                    TVBroadcastReceiver.EXTRA_INCOMING_CALL_IGNORED_REASON,
+                    arrayOf("Already on a call and `allowIncomingWhileBusy` is disabled.")
+                )
+                putExtra(TVBroadcastReceiver.EXTRA_CALL_HANDLE, callInvite.callSid)
+                LocalBroadcastManager.getInstance(context).sendBroadcast(this)
+            }
+
+            callInvite.reject(context)
+            return
+        }
+
         // Get TelecomManager instance
         val tm = context.getSystemService(Context.TELECOM_SERVICE) as TelecomManager
 
-        val shouldRejectOnNoPermissions: Boolean = StorageImpl(context).rejectOnNoPermissions
+        val shouldRejectOnNoPermissions: Boolean = storage.rejectOnNoPermissions
         var missingPermissions: Array<String> = emptyArray()
 
         // Check permission READ_PHONE_STATE

--- a/android/src/main/kotlin/com/twilio/twilio_voice/storage/Storage.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/storage/Storage.kt
@@ -38,6 +38,13 @@ interface Storage {
     var rejectOnNoPermissions: Boolean
 
     /**
+     * If false, incoming call invites received while a call belonging to this plugin is already
+     * active are rejected immediately. Default is true.
+     * @return true to allow incoming calls while busy, false to reject them.
+     */
+    var allowIncomingWhileBusy: Boolean
+
+    /**
      * Get the default caller name, if not set, return the default [Constants.DEFAULT_UNKNOWN_CALLER]
      * @param id: the id of the registered client
      * @return the default caller name

--- a/android/src/main/kotlin/com/twilio/twilio_voice/storage/StorageImpl.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/storage/StorageImpl.kt
@@ -11,6 +11,7 @@ class StorageImpl(ctx: Context) : Storage {
     private val kDefaultCaller: String = "defaultCaller"
     private val kRejectOnNoPermissions: String = "rejectOnNoPermissions"
     private val kShowNotifications: String = "show-notifications"
+    private val kAllowIncomingWhileBusy: String = "allowIncomingWhileBusy"
 
     override var defaultCaller
         get() = prefs.getString(kDefaultCaller, null)
@@ -26,6 +27,14 @@ class StorageImpl(ctx: Context) : Storage {
         set(value) {
             val editor = prefs.edit()
             editor.putBoolean(kRejectOnNoPermissions, value)
+            editor.apply()
+        }
+
+    override var allowIncomingWhileBusy
+        get() = prefs.getBoolean(kAllowIncomingWhileBusy, true)
+        set(value) {
+            val editor = prefs.edit()
+            editor.putBoolean(kAllowIncomingWhileBusy, value)
             editor.apply()
         }
 

--- a/android/src/main/kotlin/com/twilio/twilio_voice/types/TVMethodChannels.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/types/TVMethodChannels.kt
@@ -46,6 +46,8 @@ enum class TVMethodChannels(val method: String) {
     REQUEST_BACKGROUND_PERMISSIONS("requestBackgroundPermissions"),
     IS_PHONE_ACCOUNT_ENABLED("isPhoneAccountEnabled"),
     REJECT_CALL_ON_NO_PERMISSIONS("rejectCallOnNoPermissions"),
+    SET_ALLOW_INCOMING_WHILE_BUSY("setAllowIncomingWhileBusy"),
+    GET_ALLOW_INCOMING_WHILE_BUSY("getAllowIncomingWhileBusy"),
     IS_REJECTING_CALL_ON_NO_PERMISSIONS("isRejectingCallOnNoPermissions"),
     UPDATE_CALLKIT_ICON("updateCallKitIcon"),
     CONNECT("connect");

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -11,6 +11,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
     
     final let defaultCallKitIcon = "callkit_icon"
     final let callLoggingEnabledKey = "TV_CALL_LOGGING_ENABLED"
+    final let allowIncomingWhileBusyKey = "TV_ALLOW_INCOMING_WHILE_BUSY"
     var callKitIcon: String?
 
     var _result: FlutterResult?
@@ -374,6 +375,16 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
             // update icon & persist
             result(updateCallKitIcon(icon: newIcon))
             return
+        } else if flutterCall.method == "setAllowIncomingWhileBusy" {
+            guard let allow = arguments["allow"] as? Bool else {
+                result(FlutterError(code: "MALFORMED_ARGUMENTS", message: "No 'allow' argument provided or invalid type", details: nil))
+                return
+            }
+            UserDefaults.standard.set(allow, forKey: allowIncomingWhileBusyKey)
+            result(true)
+        } else if flutterCall.method == "getAllowIncomingWhileBusy" {
+            // Mirror the default used by callInviteReceived when the key was never set.
+            result(UserDefaults.standard.optionalBool(forKey: allowIncomingWhileBusyKey) ?? true)
         } else if flutterCall.method == "enableCallLogging" {
             let value = arguments["enable"] as? Bool ?? true
             
@@ -687,7 +698,17 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         
         var from:String = callInvite.from ?? defaultCaller
         from = from.replacingOccurrences(of: "client:", with: "")
-        
+
+        // Check if the user has allowed incoming calls while busy. If not, reject the call invite if there is an active call or call invite.
+        // Ensure we report a failed call to CallKit.
+        let allowIncomingWhileBusy = UserDefaults.standard.optionalBool(forKey: allowIncomingWhileBusyKey) ?? true
+        if !allowIncomingWhileBusy && (self.call != nil || self.callInvite != nil) {
+            self.sendPhoneCallEvents(description: "LOG|callInviteReceived: already on a call and allowIncomingWhileBusy is false, rejecting", isError: false)
+            reportFailedIncomingCall()
+            callInvite.reject()
+            return
+        }
+
         self.sendPhoneCallEvents(description: "Incoming|\(from)|\(callInvite.to)|Incoming\(formatCustomParams(params: callInvite.customParameters))", isError: false)
         self.sendPhoneCallEvents(description: "Ringing|\(from)|\(callInvite.to)|Incoming\(formatCustomParams(params: callInvite.customParameters))", isError: false)
         reportIncomingCall(from: from, uuid: callInvite.uuid)

--- a/lib/_internal/local_storage_web/i_local_storage_web.dart
+++ b/lib/_internal/local_storage_web/i_local_storage_web.dart
@@ -3,6 +3,7 @@ import 'package:web/web.dart';
 abstract class ILocalStorageWeb {
   /// local storage mapping keys
   final String kDefaultCallerName = "kDefaultCallerName";
+  final String kAllowIncomingWhileBusy = "kAllowIncomingWhileBusy";
 
   Storage get localStorage;
 
@@ -11,6 +12,13 @@ abstract class ILocalStorageWeb {
 
   /// Get default caller name for incoming calls if no caller name is provided / registered.
   String getDefaultCallerName(String defaultValue);
+
+  /// Whether the Twilio Device should raise `incoming` while already on a call.
+  void saveAllowIncomingWhileBusy(bool value);
+
+  /// Whether the Twilio Device should raise `incoming` while already on a call, or [defaultValue]
+  /// when never set.
+  bool getAllowIncomingWhileBusy(bool defaultValue);
 
   /// Add registered client by [id, name] pair in local storage. If an existing client with the same id is already registered, it will be replaced.
   void addRegisteredClient(String id, String name);

--- a/lib/_internal/local_storage_web/local_storage_web.dart
+++ b/lib/_internal/local_storage_web/local_storage_web.dart
@@ -22,6 +22,18 @@ class LocalStorageWeb extends ILocalStorageWeb {
   }
 
   @override
+  bool getAllowIncomingWhileBusy(bool defaultValue) {
+    final value = _localStorage.getItem(kAllowIncomingWhileBusy);
+    if (value == null) return defaultValue;
+    return value == "true";
+  }
+
+  @override
+  void saveAllowIncomingWhileBusy(bool value) {
+    _localStorage.setItem(kAllowIncomingWhileBusy, value.toString());
+  }
+
+  @override
   void addRegisteredClient(String id, String name) {
     _localStorage.setItem(id, name);
   }

--- a/lib/_internal/method_channel/twilio_voice_method_channel.dart
+++ b/lib/_internal/method_channel/twilio_voice_method_channel.dart
@@ -249,6 +249,22 @@ class MethodChannelTwilioVoice extends TwilioVoicePlatform {
     return _channel.invokeMethod<bool?>('rejectCallOnNoPermissions', {"shouldReject": shouldReject}).then<bool>((bool? value) => value ?? false);
   }
 
+  /// Whether an incoming call invite is accepted while a call handled by this plugin is already
+  /// active. Defaults to true.
+  ///
+  /// "Busy" only considers calls belonging to this plugin - an unrelated SIM/carrier call does not
+  /// count.
+  @override
+  Future<bool> setAllowIncomingWhileBusy({bool allow = true}) {
+    return _channel.invokeMethod<bool?>('setAllowIncomingWhileBusy', {"allow": allow}).then<bool>((bool? value) => value ?? false);
+  }
+
+  /// Whether incoming calls are raised while already on a call. Defaults to true.
+  @override
+  Future<bool> getAllowIncomingWhileBusy() {
+    return _channel.invokeMethod<bool?>('getAllowIncomingWhileBusy', {}).then<bool>((bool? value) => value ?? true);
+  }
+
   /// Returns true if call is rejected when no `CALL_PHONE` permissions are granted nor Phone Account (via `isPhoneAccountEnabled`) is registered. Defaults to false.
   ///
   /// Only available on Android

--- a/lib/_internal/platform_interface/twilio_voice_platform_interface.dart
+++ b/lib/_internal/platform_interface/twilio_voice_platform_interface.dart
@@ -149,6 +149,16 @@ abstract class TwilioVoicePlatform extends SharedPlatformInterface {
   /// Only available on Android
   Future<bool> rejectCallOnNoPermissions({bool shouldReject = false});
 
+  /// Whether an incoming call invite is accepted while a call handled by this plugin is already
+  /// active. If set to false, the next incoming call invite is rejected immediately. If set to true, the next incoming call invite is accepted and a second call is created. Defaults to true.
+  ///
+  /// Note: the concept of "busy" refers to calls belonging to this plugin - on Android an unrelated SIM/carrier call
+  /// does not count.
+  Future<bool> setAllowIncomingWhileBusy({bool allow = true});
+
+  /// Whether incoming calls are raised while already on a call. Defaults to true.
+  Future<bool> getAllowIncomingWhileBusy();
+
   /// Returns true if call is rejected when no `CALL_PHONE` permissions are granted nor Phone Account (via `isPhoneAccountEnabled`) is registered. Defaults to false.
   ///
   /// Only available on Android

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -105,6 +105,12 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
 
   late final Call _call = Call();
 
+  /// Whether the Twilio Device raises `incoming` while already on a call.
+  /// Mirrors the SDK's `allowIncomingWhileBusy` device option. See [setAllowIncomingWhileBusy].
+  bool get _allowIncomingWhileBusy => _localStorage.getAllowIncomingWhileBusy(true);
+
+  set _allowIncomingWhileBusy(bool value) => _localStorage.saveAllowIncomingWhileBusy(value);
+
   @override
   Call get call => _call;
 
@@ -208,6 +214,19 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
   Future<bool?> updateCallKitIcon({String? icon}) async {
     return true;
   }
+
+  /// Whether the Twilio Device raises `incoming` while already on a call, via the SDK's
+  /// `allowIncomingWhileBusy` device option. Applied to the active device immediately.
+  @override
+  Future<bool> setAllowIncomingWhileBusy({bool allow = true}) async {
+    _allowIncomingWhileBusy = allow;
+    device?.updateOptions(_deviceOptions);
+    return true;
+  }
+
+  /// Whether the Twilio Device raises `incoming` while already on a call. Defaults to true.
+  @override
+  Future<bool> getAllowIncomingWhileBusy() async => _allowIncomingWhileBusy;
 
   /// Set default caller name for incoming calls if no caller name is provided / registered.
   /// See [LocalStorageWeb.saveDefaultCallerName]
@@ -419,7 +438,7 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
           codecPreferences: codecs.map((e) => e.toJS).toList().toJS,
           closeProtection: true,
           enableImprovedSignalingErrorPrecision: true,
-          allowIncomingWhileBusy: false,
+          allowIncomingWhileBusy: _allowIncomingWhileBusy,
         );
 
         /// create new Twilio device
@@ -609,7 +628,7 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
       codecPreferences: _codecs.map((e) => e.toJS).toList().toJS,
       closeProtection: _closeProtection,
       enableImprovedSignalingErrorPrecision: true,
-      allowIncomingWhileBusy: false,
+      allowIncomingWhileBusy: _allowIncomingWhileBusy,
       sounds: _soundMap.jsify(),
     );
   }

--- a/macos/Classes/JsInterop/Device/TVDevice.swift
+++ b/macos/Classes/JsInterop/Device/TVDevice.swift
@@ -69,6 +69,23 @@ public class TVDevice: JSObject, TVDeviceDelegate, JSMessageHandlerDelegate {
         }
     }
 
+    /// Update the device's options, e.g. to change `allowIncomingWhileBusy` on an already-created
+    /// device without re-registering it.
+    /// - Parameters:
+    ///   - options: the new device options
+    ///   - completionHandler: completion handler
+    /// - SeeAlso: Twilio [Device.updateOptions](https://www.twilio.com/docs/voice/sdks/javascript/twiliodevice#deviceupdateoptionsoptions)
+    func updateOptions(_ options: DeviceInitOptions, completionHandler: @escaping OnCompletionValueHandler<Bool>) -> Void {
+        call(method: "updateOptions", withArgs: [options]) { result, error in
+            if let error = error {
+                print("Error TVDevice:updateOptions : \(String(describing: error))")
+                completionHandler(false)
+                return
+            }
+            completionHandler(true)
+        }
+    }
+
     /// Connect this device to Twilio Application to engage in a call
     /// - Parameters
     ///   - options: connect options, includes params [Constants.PARAM_TO, Constants.PARAM_FROM, Constants.PARAM_CUSTOM_PARAMETERS]

--- a/macos/Classes/TwilioVoiceChannelMethods.swift
+++ b/macos/Classes/TwilioVoiceChannelMethods.swift
@@ -29,4 +29,6 @@ public enum TwilioVoiceChannelMethods: String {
     case requestBackgroundPermissions = "requestBackgroundPermissions"
     case showNotifications = "showNotifications"
     case updateCallKitIcon = "updateCallKitIcon"
+    case setAllowIncomingWhileBusy = "setAllowIncomingWhileBusy"
+    case getAllowIncomingWhileBusy = "getAllowIncomingWhileBusy"
 }

--- a/macos/Classes/TwilioVoicePlugin.swift
+++ b/macos/Classes/TwilioVoicePlugin.swift
@@ -31,6 +31,19 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
     private var clients: [String: String]!
 
     var defaultCaller = "Unknown Caller"
+
+    /// Storage key for [allowIncomingWhileBusy].
+    private let allowIncomingWhileBusyKey = "TV_ALLOW_INCOMING_WHILE_BUSY"
+
+    /// Whether the Twilio Device raises `incoming` while already on a call. Defaults to true; see `setAllowIncomingWhileBusy`.
+    private var allowIncomingWhileBusy: Bool {
+        get {
+            UserDefaults.standard.optionalBool(forKey: allowIncomingWhileBusyKey) ?? true
+        }
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: allowIncomingWhileBusyKey)
+        }
+    }
     var deviceToken: Data? {
         get {
             UserDefaults.standard.data(forKey: kCachedDeviceToken)
@@ -155,7 +168,7 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
         assert(token.isNotEmpty(), "Access token cannot be empty")
 
         let codecs: [String] = ["opus", "pcmu"]
-        let options: DeviceInitOptions = DeviceInitOptions(logLevel: 1, codecPreferences: codecs, closeProtection: false, allowIncomingWhileBusy: false)
+        let options: DeviceInitOptions = DeviceInitOptions(logLevel: 1, codecPreferences: codecs, closeProtection: false, allowIncomingWhileBusy: allowIncomingWhileBusy)
         if let device = twilioDevice {
             device.updateToken(token) { (value) in
                 completionHandler(value ?? false)
@@ -902,6 +915,26 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
             }
 
             result(showNotifications(show))
+            break
+
+        case .setAllowIncomingWhileBusy:
+            guard let allow = arguments["allow"] as? Bool else {
+                let ferror: FlutterError = FlutterError(code: FlutterErrorCodes.MALFORMED_ARGUMENTS, message: "Argument 'allow' missing or incorrect type", details: nil)
+                result(ferror)
+                return
+            }
+
+            allowIncomingWhileBusy = allow
+            // Apply to the active device, if any; otherwise it is picked up on the next setTokens.
+            if let device = twilioDevice {
+                let codecs: [String] = ["opus", "pcmu"]
+                device.updateOptions(DeviceInitOptions(logLevel: 1, codecPreferences: codecs, closeProtection: false, allowIncomingWhileBusy: allow)) { _ in }
+            }
+            result(true)
+            break
+
+        case .getAllowIncomingWhileBusy:
+            result(allowIncomingWhileBusy)
             break
 
         case .updateCallKitIcon:


### PR DESCRIPTION
This pull request introduces a new feature that allows developers to control whether multiple incoming call invites are allowed while already on a call, via a new `setAllowIncomingWhileBusy(allow: bool)` API. By default, all platforms allow multiple incoming calls, but this can now be toggled at runtime. The implementation includes updates across Android, iOS, macOS, and Web platforms, as well as the Dart platform interface and storage layers. The most important changes are summarized below.

---

**New Feature: Allow Incoming Calls While Busy**

* Added the `setAllowIncomingWhileBusy(allow: bool)` and `getAllowIncomingWhileBusy()` methods to the platform interface (`TwilioVoicePlatform`), enabling control over whether multiple incoming call invites are allowed. Defaults to true. [[1]](diffhunk://#diff-ce11a0cef1a99a048f5c0d1ea068bc58eff0f79e156502b0f07aae8dcd650e8fR152-R161) [[2]](diffhunk://#diff-a9ba6296b92dfa32f726b72d4898fe4c2fac7705ecf47cdc6b269538352c5ed1R252-R267) [[3]](diffhunk://#diff-cc5884836157f98dd48294d6fab6b927c8446031ed43e7ebaee63a5872bc16bcR49-R50) [[4]](diffhunk://#diff-f4fe4da52dc25868112354858026b1759258869ae13638e6fedc7c0aec8ff362R32-R33) [[5]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR82)

**Android Implementation**

* Implemented persistent storage and retrieval of the `allowIncomingWhileBusy` flag in `Storage`/`StorageImpl`, and enforced the policy in the FCM message handler to reject new incoming calls if set to false and a call is active. [[1]](diffhunk://#diff-1ca37b6010f1f79a0cc977609a27534e9b6f15d9be0717edbc71a65263f2b66aR40-R46) [[2]](diffhunk://#diff-b126071f924befb6297c8b4166abbfaa2b2a5298c27bd13f7fc4b4a1a1039c3dR14) [[3]](diffhunk://#diff-b126071f924befb6297c8b4166abbfaa2b2a5298c27bd13f7fc4b4a1a1039c3dR33-R40) [[4]](diffhunk://#diff-dc47ee7b3a3c9a2162eb8e618d867510a95cd68eeff16c627616c779dcbe8dafR96-R123) [[5]](diffhunk://#diff-cd8db83ca5629b36aee8f06cc66647fd892275a6b495af68bcb5915a85858f37R999-R1033)

**iOS/macOS Implementation**

* Added support for the new setting in `SwiftTwilioVoicePlugin` and `TwilioVoicePlugin` (macOS), persisting the value in `UserDefaults`, and enforcing the policy to reject new incoming calls if set to false and already on a call. [[1]](diffhunk://#diff-dcc6535a9a0005d0fa59b345bcebdc26a06a66a5505e3b69ecf3c948baedb0daR14) [[2]](diffhunk://#diff-dcc6535a9a0005d0fa59b345bcebdc26a06a66a5505e3b69ecf3c948baedb0daR378-R387) [[3]](diffhunk://#diff-dcc6535a9a0005d0fa59b345bcebdc26a06a66a5505e3b69ecf3c948baedb0daR702-R711) [[4]](diffhunk://#diff-7b3b667ae2ce5480b269f578d1d9dc363c808c1b105ab0e2f68d5568267ac51eR34-R46) [[5]](diffhunk://#diff-7b3b667ae2ce5480b269f578d1d9dc363c808c1b105ab0e2f68d5568267ac51eL158-R171)

**Web Implementation**

* Added local storage support for the flag and updated the Twilio Device options to respect the `allowIncomingWhileBusy` setting. Provided Dart-side methods to set/get the value, and ensured the device is updated immediately when changed. [[1]](diffhunk://#diff-743f13df07f1c740df7973391f017ff44ebafe563f180b88236c9e8a934b2af3R6) [[2]](diffhunk://#diff-743f13df07f1c740df7973391f017ff44ebafe563f180b88236c9e8a934b2af3R16-R22) [[3]](diffhunk://#diff-3dad8132ac0a2a4d73a681b5ad66cf95a20bdf1284213d60389484163edc191eR24-R35) [[4]](diffhunk://#diff-ec6e948d7a10d3f7a327011474bd335b572a8b9bc2864cef0c29afe08c4a5140R108-R113) [[5]](diffhunk://#diff-ec6e948d7a10d3f7a327011474bd335b572a8b9bc2864cef0c29afe08c4a5140R218-R230) [[6]](diffhunk://#diff-ec6e948d7a10d3f7a327011474bd335b572a8b9bc2864cef0c29afe08c4a5140L422-R441) [[7]](diffhunk://#diff-ec6e948d7a10d3f7a327011474bd335b572a8b9bc2864cef0c29afe08c4a5140L612-R631)

**Changelog and Documentation**

* Updated `CHANGELOG.md` to document the new feature and its default behavior.