### PR TITLE
feat: add call quality metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Next Release
+
+* feat: added call quality events for all platforms (see `CallQualityEvent` and `TwilioVoicePlatform.instance.call.qualityWarnings`, and [Twilio Call Quality Metrics](https://www.twilio.com/docs/voice/voice-insights/api/call/details-sdk-call-quality-events#error-and-warning-events))
+* Updated Example
+* Updated docs
+
 ## 0.4.0
 
 * **BREAKING CHANGES:**

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Any and all [Feature Requests](https://github.com/cybex-dev/twilio_voice/issues/
 - Receive and place calls from Web [v2.18.0](https://www.twilio.com/docs/voice/sdks/javascript/changelog#2180-january-5-2026) (FCM push notification integration not yet supported by Twilio Voice Web, see [here](https://github.com/twilio/twilio-voice.js/pull/159#issuecomment-1551553299) for discussion)
 - Receive and place calls from MacOS devices, uses custom UI to receive calls (in future & macOS
   13.0+, we'll be using CallKit) based on [v2.18.0](https://www.twilio.com/docs/voice/sdks/javascript/changelog#2180-january-5-2026)
+- Get live [call quality metrics](https://www.twilio.com/docs/voice/voice-insights/api/call/call-metrics-resource).
 - Interpret TwiML parameters to populate UI, see below [Interpreting Parameters](#interpreting-parameters)
 
 ### Feature addition schedule:
@@ -575,6 +576,27 @@ Receives calls via [ConnectionService](https://developer.android.com/reference/a
  TwilioVoicePlatform.instance.call.sendDigits(String digits);
 
 ```
+
+#### Call Quality Metrics
+
+Retrieve call quality warnings for an active call using:
+
+```dart
+final warnings = [CallQualityWarning.highPacketLoss, CallQualityWarning.highJitter, CallQualityWarning.highRtt];
+Stream<CallQualityEvent> qualityEventStream = TwilioVoicePlatform.instance.call.qualityWarnings;
+qualityEventStream.listen((e) {
+    final isBadCallQuality = e.current.any((e) => warnings.contains(e));
+    print("Call Quality: ${isBadCallQuality ? "Bad" : "Good"}");
+});
+```
+
+or get last call quality metrics using:
+```dart
+final lastCallQuality = TwilioVoicePlatform.instance.call.lastQualityWarnings;
+print("Last Call Quality: ${lastCallQuality.current}");
+```
+
+TwilioVoicePlatform.instance.call.`. This returns a `CallQualityMetrics` object with the following fields:
 
 ### Permissions
 

--- a/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
@@ -1438,6 +1438,7 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
                 addAction(TVNativeCallEvents.EVENT_CONNECT_FAILURE)
                 addAction(TVNativeCallEvents.EVENT_RECONNECTING)
                 addAction(TVNativeCallEvents.EVENT_RECONNECTED)
+                addAction(TVNativeCallEvents.EVENT_QUALITY_WARNINGS_CHANGED)
                 addAction(TVNativeCallEvents.EVENT_DISCONNECTED_LOCAL)
                 addAction(TVNativeCallEvents.EVENT_DISCONNECTED_REMOTE)
                 addAction(TVNativeCallEvents.EVENT_MISSED)
@@ -1977,6 +1978,12 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
 
             TVNativeCallEvents.EVENT_RECONNECTING -> {
                 logEvent("", "Reconnecting");
+            }
+
+            TVNativeCallEvents.EVENT_QUALITY_WARNINGS_CHANGED -> {
+                val current = intent.getStringExtra(TVBroadcastReceiver.EXTRA_QUALITY_WARNINGS_CURRENT) ?: ""
+                val previous = intent.getStringExtra(TVBroadcastReceiver.EXTRA_QUALITY_WARNINGS_PREVIOUS) ?: ""
+                logEvents("", arrayOf("Quality", current, previous))
             }
 
             TVNativeCallEvents.EVENT_RECONNECTED -> {

--- a/android/src/main/kotlin/com/twilio/twilio_voice/receivers/TVBroadcastReceiver.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/receivers/TVBroadcastReceiver.kt
@@ -51,6 +51,18 @@ class TVBroadcastReceiver(private val plugin: TwilioVoicePlugin) : BroadcastRece
         /**
          * Extra used with [ACTION_ACTIVE_CALL_CHANGED], [ACTION_CALL_ENDED] providing the active call handle.
          */
+        /**
+         * Extra used with [TVNativeCallEvents.EVENT_QUALITY_WARNINGS_CHANGED], a comma-separated
+         * list of currently active call quality warning names.
+         */
+        const val EXTRA_QUALITY_WARNINGS_CURRENT: String = "EXTRA_QUALITY_WARNINGS_CURRENT"
+
+        /**
+         * Extra used with [TVNativeCallEvents.EVENT_QUALITY_WARNINGS_CHANGED], a comma-separated
+         * list of the previously active call quality warning names.
+         */
+        const val EXTRA_QUALITY_WARNINGS_PREVIOUS: String = "EXTRA_QUALITY_WARNINGS_PREVIOUS"
+
         const val EXTRA_CALL_HANDLE: String = "EXTRA_CALL_HANDLE"
 
         /**

--- a/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnection.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnection.kt
@@ -265,6 +265,41 @@ open class TVCallConnection(
     }
 
     /**
+     * The Twilio SDK raises this when the set of active call quality warnings changes, i.e. when a
+     * metric (RTT, jitter, packet loss, MOS, audio levels) crosses a threshold or recovers.
+     *
+     * @see https://www.javadoc.io/static/com.twilio/voice-android/6.10.0/com/twilio/voice/Call.Listener.html#onCallQualityWarningsChanged(Call,Set,Set)
+     */
+    override fun onCallQualityWarningsChanged(
+        call: Call,
+        currentWarnings: MutableSet<Call.CallQualityWarning>,
+        previousWarnings: MutableSet<Call.CallQualityWarning>
+    ) {
+        Log.d(TAG, "onCallQualityWarningsChanged: current=$currentWarnings, previous=$previousWarnings")
+        onEvent?.onChange(TVNativeCallEvents.EVENT_QUALITY_WARNINGS_CHANGED, Bundle().apply {
+            putString(TVBroadcastReceiver.EXTRA_CALL_HANDLE, callParams?.callSid)
+            putString(TVBroadcastReceiver.EXTRA_QUALITY_WARNINGS_CURRENT, currentWarnings.toWireNames())
+            putString(TVBroadcastReceiver.EXTRA_QUALITY_WARNINGS_PREVIOUS, previousWarnings.toWireNames())
+        })
+    }
+
+    /**
+     * Maps Twilio's [Call.CallQualityWarning] values onto the plugin's cross-platform wire names.
+     *
+     * @see https://www.javadoc.io/static/com.twilio/voice-android/6.10.0/com/twilio/voice/Call.CallQualityWarning.html
+     */
+    private fun Set<Call.CallQualityWarning>.toWireNames(): String = joinToString(",") {
+        when (it) {
+            Call.CallQualityWarning.WARN_HIGH_RTT -> "high-rtt"
+            Call.CallQualityWarning.WARN_HIGH_JITTER -> "high-jitter"
+            Call.CallQualityWarning.WARN_HIGH_PACKET_LOSS -> "high-packet-loss"
+            Call.CallQualityWarning.WARN_LOW_MOS -> "low-mos"
+            Call.CallQualityWarning.WARN_CONSTANT_AUDIO_IN_LEVEL -> "constant-audio-input-level"
+            Call.CallQualityWarning.WARN_CONSTANT_AUDIO_OUTPUT_LEVEL -> "constant-audio-output-level"
+        }
+    }
+
+    /**
      * The call is reconnected.
      *
      * @param call An object model representing a call.

--- a/android/src/main/kotlin/com/twilio/twilio_voice/types/TVNativeCallEvents.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/types/TVNativeCallEvents.kt
@@ -43,6 +43,11 @@ object TVNativeCallEvents {
     val EVENT_RECONNECTED: String = "com.twilio.EVENT_RECONNECTED"
 
     /**
+     * The event name for when the set of active call quality warnings changes.
+     */
+    val EVENT_QUALITY_WARNINGS_CHANGED: String = "com.twilio.EVENT_QUALITY_WARNINGS_CHANGED"
+
+    /**
      * The event name for when a call is disconnected locally
      */
     val EVENT_DISCONNECTED_LOCAL: String = "com.twilio.EVENT_DISCONNECTED_LOCAL"

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "com.android.application"
+    id 'com.google.gms.google-services'
     id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
 }

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -19,6 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "$agpVersion" apply false
+    id "com.google.gms.google-services" version "4.3.15" apply false
     id "org.jetbrains.kotlin.android" version "$kotlinVersion" apply false
 }
 

--- a/example/lib/screens/widgets/call_status.dart
+++ b/example/lib/screens/widgets/call_status.dart
@@ -52,7 +52,7 @@ class _CallStatusState extends State<CallStatus> {
         // Labels
         const Column(
           crossAxisAlignment: CrossAxisAlignment.start,
-          children: [Text("From:"), Text("To:"), Text("Direction:"), Text("SID:"), Text("State:")],
+          children: [Text("From:"), Text("To:"), Text("Direction:"), Text("SID:"), Text("State:"), Text("Quality:")],
         ),
 
         // Spacer
@@ -68,6 +68,7 @@ class _CallStatusState extends State<CallStatus> {
               activeCall != null ? Text(activeCall.callDirection == CallDirection.incoming ? "Incoming" : "Outgoing") : const Text("N/A"),
               _CallSID(),
               _events.isEmpty ? const Text("N/A") : Text(_events.last.toString()),
+              _CallQuality(),
             ],
           ),
         ),
@@ -129,6 +130,31 @@ class _StatusIcon extends StatelessWidget {
       ),
       width: 16,
       height: 16,
+    );
+  }
+}
+
+class _CallQuality extends StatelessWidget {
+  const _CallQuality({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder(
+      stream: TwilioVoicePlatform.instance.call.qualityWarnings,
+      builder: (context, snapshot) {
+        if(TwilioVoicePlatform.instance.call.activeCall == null) {
+          return const Text("N/A");
+        }
+        if(snapshot.hasError) {
+          return Text("Error: ${snapshot.error}");
+        }
+        final warnings = snapshot.data?.current ?? {};
+        if (warnings.isEmpty) {
+          return const Text("Good");
+        } else {
+          return Text(warnings.map((e) => e.name).join(", "));
+        }
+      },
     );
   }
 }

--- a/example/lib/screens/widgets/call_status.dart
+++ b/example/lib/screens/widgets/call_status.dart
@@ -135,7 +135,7 @@ class _StatusIcon extends StatelessWidget {
 }
 
 class _CallQuality extends StatelessWidget {
-  const _CallQuality({super.key});
+  const _CallQuality();
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/screens/widgets/call_status.dart
+++ b/example/lib/screens/widgets/call_status.dart
@@ -68,7 +68,7 @@ class _CallStatusState extends State<CallStatus> {
               activeCall != null ? Text(activeCall.callDirection == CallDirection.incoming ? "Incoming" : "Outgoing") : const Text("N/A"),
               _CallSID(),
               _events.isEmpty ? const Text("N/A") : Text(_events.last.toString()),
-              _CallQuality(),
+              const _CallQuality(),
             ],
           ),
         ),

--- a/ios/Classes/SwiftTwilioVoicePlugin.swift
+++ b/ios/Classes/SwiftTwilioVoicePlugin.swift
@@ -794,6 +794,28 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         self.sendPhoneCallEvents(description: "Reconnected", isError: false)
     }
 
+    /// Source: https://twilio.github.io/twilio-voice-ios/docs/latest/Protocols/TVOCallDelegate.html#//api/name/call:didReceiveQualityWarnings:previousWarnings:
+    public func callDidReceiveQualityWarnings(call: Call, currentWarnings: Set<NSNumber>, previousWarnings: Set<NSNumber>) {
+        let current = wireNames(for: currentWarnings)
+        let previous = wireNames(for: previousWarnings)
+        self.sendPhoneCallEvents(description: "Quality|\(current)|\(previous)", isError: false)
+    }
+
+    /// Source: https://twilio.github.io/twilio-voice-ios/docs/latest/Constants/TVOCallQualityWarning.html
+    private func wireNames(for warnings: Set<NSNumber>) -> String {
+        return warnings.compactMap { warning -> String? in
+            guard let value = Call.QualityWarning(rawValue: warning.uintValue) else { return nil }
+            switch value {
+            case .highRtt: return "high-rtt"
+            case .highJitter: return "high-jitter"
+            case .highPacketsLostFraction: return "high-packet-loss"
+            case .lowMos: return "low-mos"
+            case .constantAudioInputLevel: return "constant-audio-input-level"
+            @unknown default: return nil
+            }
+        }.joined(separator: ",")
+    }
+
     public func callDidFailToConnect(call: Call, error: Error) {
         self.sendPhoneCallEvents(description: "LOG|Call failed to connect: \(error.localizedDescription)", isError: false)
         self.sendPhoneCallEvents(description: "Call Ended", isError: false)

--- a/lib/_internal/js/call/call.dart
+++ b/lib/_internal/js/call/call.dart
@@ -26,9 +26,9 @@ enum TwilioCallEvents {
   // "sample"
   // sample,
   // "warning"
-  // warning,
-  // "warningCleared"
-  // warningCleared,
+  warning,
+  // "warning-cleared"
+  warningCleared,
   // "connected", undocumented?
   connected,
 }

--- a/lib/_internal/method_channel/twilio_call_method_channel.dart
+++ b/lib/_internal/method_channel/twilio_call_method_channel.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 import 'package:twilio_voice/twilio_voice.dart';
 
+import '../../models/call_quality_event.dart';
 import '../platform_interface/twilio_call_platform_interface.dart';
 
 // abstract class MethodChannelTwilioCall extends TwilioVoiceSharedPlatform {
@@ -13,6 +16,17 @@ class MethodChannelTwilioCall extends TwilioCallPlatform {
   @override
   set activeCall(ActiveCall? activeCall) {
     _activeCall = activeCall;
+  }
+
+  /// Container for last call quality, null if none are reported or no call active.
+  static CallQualityEvent? _lastQualityWarnings;
+
+  /// Call quality warnings for a call reported by Twilio SDK. Warnings apply to the current ongoing call. Last quality reported stored in [lastQualityWarnings].
+  // ignore: close_sinks
+  static StreamController<CallQualityEvent>? _qualityWarningsController;
+  StreamController<CallQualityEvent> get qualityWarningsController {
+    _qualityWarningsController ??= StreamController<CallQualityEvent>.broadcast();
+    return _qualityWarningsController!;
   }
 
   MethodChannel get _channel => sharedChannel;
@@ -121,5 +135,24 @@ class MethodChannelTwilioCall extends TwilioCallPlatform {
       ...?extraOptions,
     };
     return _channel.invokeMethod('connect', options);
+  }
+
+  /// Stream of [CallQualityEvent]s for current call.
+  @override
+  Stream<CallQualityEvent> get qualityWarnings => qualityWarningsController.stream;
+
+  /// The most recent [CallQualityEvent], or null if none has been reported for the current call.
+  @override
+  CallQualityEvent? get lastQualityWarnings => _lastQualityWarnings;
+
+  @override
+  void updateQualityWarnings(CallQualityEvent event) {
+    _lastQualityWarnings = event;
+    qualityWarningsController.add(event);
+  }
+
+  @override
+  void clearQualityWarnings() {
+    _lastQualityWarnings = null;
   }
 }

--- a/lib/_internal/method_channel/twilio_call_method_channel.dart
+++ b/lib/_internal/method_channel/twilio_call_method_channel.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/services.dart';
 import 'package:twilio_voice/twilio_voice.dart';
 
-import '../../models/call_quality_event.dart';
 import '../platform_interface/twilio_call_platform_interface.dart';
 
 // abstract class MethodChannelTwilioCall extends TwilioVoiceSharedPlatform {

--- a/lib/_internal/method_channel/twilio_voice_method_channel.dart
+++ b/lib/_internal/method_channel/twilio_voice_method_channel.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
-import '../../models/call_quality_event.dart';
 import '../../twilio_voice.dart';
 import '../js/core/enums/device_sound_name.dart';
 import '../platform_interface/twilio_call_platform_interface.dart';

--- a/lib/_internal/method_channel/twilio_voice_method_channel.dart
+++ b/lib/_internal/method_channel/twilio_voice_method_channel.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
+import '../../models/call_quality_event.dart';
 import '../../twilio_voice.dart';
 import '../js/core/enums/device_sound_name.dart';
 import '../platform_interface/twilio_call_platform_interface.dart';
@@ -308,6 +309,17 @@ class MethodChannelTwilioVoice extends TwilioVoicePlatform {
 
   @override
   CallEvent parseCallEvent(String state) {
+    if (state.startsWith("Quality|")) {
+      // Quality|<current csv>|<previous csv> - warning names are fixed tokens containing no '|',
+      // so they are safe in the pipe-delimited protocol. The call is implied by the object the
+      // stream hangs off, so the SID is not repeated.
+      final tokens = state.split('|');
+      call.updateQualityWarnings(CallQualityEvent(
+        current: CallQualityWarning.parseAll(tokens.length > 1 ? tokens[1] : ""),
+        previous: CallQualityWarning.parseAll(tokens.length > 2 ? tokens[2] : ""),
+      ));
+      return CallEvent.log;
+    }
     if (state.startsWith("DEVICETOKEN|")) {
       var token = state.split('|')[1];
       if (deviceTokenChanged != null) {
@@ -338,18 +350,22 @@ class MethodChannelTwilioVoice extends TwilioVoicePlatform {
       // The callee is busy.
       if (tokens[1].contains("31600") || tokens[1].contains("31603") || tokens[1].contains("31486")) {
         call.activeCall = null;
+        call.clearQualityWarnings();
         return CallEvent.declined;
       } else if (tokens.toString().toLowerCase().contains("call rejected")) {
         // Android call reject from string: "LOG|Call Rejected"
         call.activeCall = null;
+        call.clearQualityWarnings();
         return CallEvent.declined;
       } else if (tokens.toString().toLowerCase().contains("rejecting call")) {
         // iOS call reject from string: "LOG|provider:performEndCallAction: rejecting call"
         call.activeCall = null;
+        call.clearQualityWarnings();
         return CallEvent.declined;
       } else if (tokens[1].contains("Call Rejected")) {
         // macOS / web call reject from string: "Call Rejected"
         call.activeCall = null;
+        call.clearQualityWarnings();
         return CallEvent.declined;
       }
       return CallEvent.log;
@@ -402,8 +418,10 @@ class MethodChannelTwilioVoice extends TwilioVoicePlatform {
         return CallEvent.connected;
       case 'Call Ended':
         call.activeCall = null;
+        call.clearQualityWarnings();
         return CallEvent.callEnded;
       case 'Missed Call':
+        call.clearQualityWarnings();
         return CallEvent.missedCall;
       case 'Unhold':
         return CallEvent.unhold;

--- a/lib/_internal/platform_interface/twilio_call_platform_interface.dart
+++ b/lib/_internal/platform_interface/twilio_call_platform_interface.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
-import '../../models/call_quality_event.dart';
 import '../../twilio_voice.dart';
 import '../method_channel/twilio_call_method_channel.dart';
 import 'shared_platform_interface.dart';

--- a/lib/_internal/platform_interface/twilio_call_platform_interface.dart
+++ b/lib/_internal/platform_interface/twilio_call_platform_interface.dart
@@ -2,11 +2,19 @@ import 'dart:async';
 
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
+import '../../models/call_quality_event.dart';
 import '../../twilio_voice.dart';
 import '../method_channel/twilio_call_method_channel.dart';
 import 'shared_platform_interface.dart';
 
 abstract class TwilioCallPlatform extends SharedPlatformInterface {
+
+  /// Stream of [CallQualityEvent]s for current call.
+  Stream<CallQualityEvent> get qualityWarnings;
+
+  /// The most recent [CallQualityEvent], or null if none has been reported for the current call.
+  CallQualityEvent? get lastQualityWarnings;
+
   TwilioCallPlatform() : super(token: _token);
 
   static final Object _token = Object();
@@ -77,4 +85,10 @@ abstract class TwilioCallPlatform extends SharedPlatformInterface {
 
   /// Send digits to active call
   Future<bool?> sendDigits(String digits);
+
+  /// Records [event] as [lastQualityWarnings] and publishes it to [qualityWarnings]. Occurs when a new [CallQualityEvent] is received from the native platform.
+  void updateQualityWarnings(CallQualityEvent event);
+
+  /// Clears [lastQualityWarnings], called when a call ends so a stale value is not reported against the next call.
+  void clearQualityWarnings();
 }

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -894,6 +894,11 @@ class Call extends MethodChannelTwilioCall {
   late final JSFunction _onCallReconnectingJs = _onCallReconnecting.toJS;
   late final JSFunction _onCallReconnectedJs = _onCallReconnected.toJS;
   late final JSFunction _onLogEventJs = _onLogEvent.toJS;
+  late final JSFunction _onCallWarningJs = _onCallWarning.toJS;
+  late final JSFunction _onCallWarningClearedJs = _onCallWarningCleared.toJS;
+
+  /// Map of last call quality warnings emitted by JS call object per call SID.
+  final Map<String, Set<CallQualityWarning>> _activeQualityWarnings = <String, Set<CallQualityWarning>>{};
 
   /// Attach event listeners to the active call
   /// See [twilio_js.Call.addListener]
@@ -909,6 +914,36 @@ class Call extends MethodChannelTwilioCall {
     call.addListener("reconnecting", _onCallReconnectingJs);
     call.addListener("reconnected", _onCallReconnectedJs);
     call.addListener("log", _onLogEventJs);
+    call.addListener("warning", _onCallWarningJs);
+    call.addListener("warning-cleared", _onCallWarningClearedJs);
+  }
+
+  /// On a call quality warning being raised, via [twilio_js.Call.addListener] and
+  /// [twilio_js.TwilioCallEvents.warning].
+  /// Documentation: https://www.twilio.com/docs/voice/sdks/javascript/twiliocall#warning-event
+  void _onCallWarning(String name) {
+    _updateQualityWarnings((set) => set.add(CallQualityWarning.fromName(name)));
+  }
+
+  /// On a call quality warning being cleared, via [twilio_js.Call.addListener] and
+  /// [twilio_js.TwilioCallEvents.warningCleared].
+  /// Documentation: https://www.twilio.com/docs/voice/sdks/javascript/twiliocall#warning-cleared-event
+  void _onCallWarningCleared(String name) {
+    _updateQualityWarnings((set) => set.remove(CallQualityWarning.fromName(name)));
+  }
+
+  /// Applies [mutate] to the active call's warning set and emits the change as
+  /// "Quality|<current csv>|<previous csv>", matching the native platforms. The SID is used only
+  /// to key the tracked set per call; it is not emitted.
+  void _updateQualityWarnings(void Function(Set<CallQualityWarning>) mutate) {
+    final sid = _getSid() ?? "";
+    final previous = Set<CallQualityWarning>.of(_activeQualityWarnings[sid] ?? const {});
+    final current = Set<CallQualityWarning>.of(previous);
+    mutate(current);
+    _activeQualityWarnings[sid] = current;
+
+    String csv(Set<CallQualityWarning> s) => s.map((e) => e.wireName).join(",");
+    logLocalEventEntries(["Quality", csv(current), csv(previous)], prefix: "");
   }
 
   /// Detach event listeners to the active call
@@ -926,6 +961,9 @@ class Call extends MethodChannelTwilioCall {
     call.removeListener("reconnecting", _onCallReconnectingJs);
     call.removeListener("reconnected", _onCallReconnectedJs);
     call.removeListener("log", _onLogEventJs);
+    call.removeListener("warning", _onCallWarningJs);
+    call.removeListener("warning-cleared", _onCallWarningClearedJs);
+    _activeQualityWarnings.remove(_getSid());
   }
 
   void _onLogEvent(String status) {

--- a/lib/models/call_quality_event.dart
+++ b/lib/models/call_quality_event.dart
@@ -1,0 +1,27 @@
+import 'call_quality_warning.dart';
+
+/// A change in the set of active [CallQualityWarning]s for a call.
+class CallQualityEvent {
+  /// The full set of warnings now active. Empty once quality has recovered.
+  final Set<CallQualityWarning> current;
+
+  /// The set of warnings active immediately before this change.
+  final Set<CallQualityWarning> previous;
+
+  const CallQualityEvent({
+    required this.current,
+    required this.previous,
+  });
+
+  /// Warnings newly raised by this change.
+  Set<CallQualityWarning> get raised => current.difference(previous);
+
+  /// Warnings newly cleared by this change.
+  Set<CallQualityWarning> get cleared => previous.difference(current);
+
+  /// Whether any warning is currently active for this call.
+  bool get hasWarnings => current.isNotEmpty;
+
+  @override
+  String toString() => 'CallQualityEvent{current: $current, previous: $previous}';
+}

--- a/lib/models/call_quality_warning.dart
+++ b/lib/models/call_quality_warning.dart
@@ -1,0 +1,81 @@
+/// Call quality warnings raised by the Twilio Voice SDK during an active call.
+///
+/// Warnings are raised when a metric crosses a threshold and cleared when it recovers, so they
+/// describe *sustained* conditions rather than instantaneous samples. Thresholds are defined by the
+/// Twilio SDKs, e.g. RTT > 400ms for 3 of the last 5 samples.
+///
+/// Availability differs by platform - see [CallQualityWarning.constantAudioOutputLevel].
+enum CallQualityWarning {
+  /// Round Trip Time is high (Twilio: RTT > 400ms for 3 of the last 5 samples).
+  highRtt,
+
+  /// Jitter is high (Twilio: jitter > 30ms for 3 of the last 5 samples).
+  highJitter,
+
+  /// A high fraction of packets is being lost (Twilio: average packet loss > 3% over 7 samples).
+  highPacketLoss,
+
+  /// Mean Opinion Score is low (Twilio: MOS < 3.5 for 3 of the last 5 samples).
+  lowMos,
+
+  /// The audio *input* level has been effectively constant, which usually means the microphone is
+  /// not picking anything up.
+  constantAudioInputLevel,
+
+  /// The audio *output* level has been effectively constant.
+  ///
+  /// **Android only** - the iOS and JS (web/macOS) SDKs do not raise this warning.
+  constantAudioOutputLevel,
+
+  /// A warning reported by the SDK that this plugin version does not recognise.
+  unknown;
+
+  /// The wire name used by the plugin's event protocol. Matches the Twilio JS SDK's warning
+  /// names, which the native platforms normalise onto.
+  String get wireName {
+    switch (this) {
+      case CallQualityWarning.highRtt:
+        return 'high-rtt';
+      case CallQualityWarning.highJitter:
+        return 'high-jitter';
+      case CallQualityWarning.highPacketLoss:
+        return 'high-packet-loss';
+      case CallQualityWarning.lowMos:
+        return 'low-mos';
+      case CallQualityWarning.constantAudioInputLevel:
+        return 'constant-audio-input-level';
+      case CallQualityWarning.constantAudioOutputLevel:
+        return 'constant-audio-output-level';
+      case CallQualityWarning.unknown:
+        return 'unknown';
+    }
+  }
+
+  /// Parses the wire name used by the plugin's event protocol.
+  static CallQualityWarning fromName(String name) {
+    switch (name) {
+      case 'high-rtt':
+        return CallQualityWarning.highRtt;
+      case 'high-jitter':
+        return CallQualityWarning.highJitter;
+      case 'high-packet-loss':
+      // Alias emitted by some Twilio JS SDK versions / matching the iOS enum name.
+      case 'high-packets-lost-fraction':
+        return CallQualityWarning.highPacketLoss;
+      case 'low-mos':
+        return CallQualityWarning.lowMos;
+      case 'constant-audio-input-level':
+        return CallQualityWarning.constantAudioInputLevel;
+      case 'constant-audio-output-level':
+        return CallQualityWarning.constantAudioOutputLevel;
+      default:
+        return CallQualityWarning.unknown;
+    }
+  }
+
+  /// Parses a comma-separated list of wire names, ignoring empty entries.
+  static Set<CallQualityWarning> parseAll(String csv) {
+    if (csv.isEmpty) return <CallQualityWarning>{};
+    return csv.split(',').where((e) => e.isNotEmpty).map(CallQualityWarning.fromName).toSet();
+  }
+}

--- a/lib/twilio_voice.dart
+++ b/lib/twilio_voice.dart
@@ -7,6 +7,8 @@ import '_internal/method_channel/twilio_voice_method_channel.dart';
 export '_internal/platform_interface/twilio_voice_platform_interface.dart' show TwilioVoicePlatform;
 export './models/active_call.dart';
 export './models/call_event.dart';
+export './models/call_quality_warning.dart';
+export './models/call_quality_event.dart';
 
 class TwilioVoice extends MethodChannelTwilioVoice {
   

--- a/macos/Classes/JsInterop/Call/TVCall.swift
+++ b/macos/Classes/JsInterop/Call/TVCall.swift
@@ -149,7 +149,7 @@ public class TVCall: JSObject, TVCallDelegate, JSMessageHandlerDelegate {
     /// - SeeAlso Twilio [Call.Events](https://www.twilio.com/docs/voice/sdks/javascript/twiliocall#events)
     func attachEventListeners() {
         print("Attaching event listeners to [TVCall]")
-        let events: [TVCallEvent] = [.accept, .cancel, .disconnect, .error, .reconnecting, .reconnected, .reject, .ringing]
+        let events: [TVCallEvent] = [.accept, .cancel, .disconnect, .error, .reconnecting, .reconnected, .reject, .ringing, .warning, .warningCleared]
         events.map {
                     $0.rawValue
                 }
@@ -264,6 +264,10 @@ public class TVCall: JSObject, TVCallDelegate, JSMessageHandlerDelegate {
         callDelegate?.onCallReject()
     }
 
+    public func onCallQualityWarning(_ name: String, isCleared: Bool) {
+        callDelegate?.onCallQualityWarning(name, isCleared: isCleared)
+    }
+
     public func onCallStatus(_ status: TVCallStatus) {
         callDelegate?.onCallStatus(status)
     }
@@ -303,6 +307,16 @@ public class TVCall: JSObject, TVCallDelegate, JSMessageHandlerDelegate {
                 break
             case .reject:
                 onCallReject()
+                break
+            case .warning:
+                if message.args.count > 0, let name = message.args[0] as? String {
+                    callDelegate?.onCallQualityWarning(name, isCleared: false)
+                }
+                break
+            case .warningCleared:
+                if message.args.count > 0, let name = message.args[0] as? String {
+                    callDelegate?.onCallQualityWarning(name, isCleared: true)
+                }
                 break
             default:
                 print("Unhandled event: \(event)")

--- a/macos/Classes/JsInterop/Call/TVCallDelegate.swift
+++ b/macos/Classes/JsInterop/Call/TVCallDelegate.swift
@@ -44,6 +44,15 @@ public protocol TVCallDelegate: AnyObject {
     /// - SeeAlso: Twilio [Call.reject](https://www.twilio.com/docs/voice/sdks/javascript/twiliocall#reject-event)
     func onCallReject() -> Void
 
+    /// A call quality warning was raised or cleared on the [TVCall].
+    ///
+    /// The JS SDK reports warnings one at a time rather than as a set.
+    ///
+    /// - Parameter name: the SDK's warning name, e.g. `high-rtt`
+    /// - Parameter isCleared: true when the warning was cleared, false when raised
+    /// - SeeAlso: Twilio [Call.warning](https://www.twilio.com/docs/voice/sdks/javascript/twiliocall#warning-event)
+    func onCallQualityWarning(_ name: String, isCleared: Bool) -> Void
+
     /// The [TVCall] status has changed.
     ///
     /// - Parameter status: [TVCallStatus] status change

--- a/macos/Classes/JsInterop/Call/Types/TVCallEvent.swift
+++ b/macos/Classes/JsInterop/Call/Types/TVCallEvent.swift
@@ -13,6 +13,6 @@ public enum TVCallEvent: String {
     case reject = "reject"
     case ringing = "ringing"
 //    case sample = "sample"
-//    case warning = "warning"
-//    case warningCleared = "warningCleared"
+    case warning = "warning"
+    case warningCleared = "warning-cleared"
 }

--- a/macos/Classes/TwilioVoicePlugin.swift
+++ b/macos/Classes/TwilioVoicePlugin.swift
@@ -48,6 +48,11 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
             }
         }
         didSet {
+            activeCallSid = nil
+            activeQualityWarnings.removeAll()
+            twilioCall?.resolveParams { [weak self] params, _ in
+                self?.activeCallSid = params?.callSid
+            }
             // attach event listeners to new call
             if let call = twilioCall {
                 call.attachEventListeners()
@@ -1386,6 +1391,22 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
 
     public func onCallReconnecting(_ error: TVError) {
         logEvent(prefix: "", description: "Reconnecting: \(error.code) \(error.message)")
+    }
+    private var activeCallSid: String?
+
+    private var activeQualityWarnings: [String: Set<String>] = [:]
+
+    public func onCallQualityWarning(_ name: String, isCleared: Bool) {
+        let sid = activeCallSid ?? ""
+        let previous = activeQualityWarnings[sid] ?? []
+        var current = previous
+        if isCleared {
+            current.remove(name)
+        } else {
+            current.insert(name)
+        }
+        activeQualityWarnings[sid] = current
+        logEvent(prefix: "", description: "Quality|\(current.joined(separator: ","))|\(previous.joined(separator: ","))")
     }
 
     public func onCallReconnected() {


### PR DESCRIPTION
This pull request adds support for live call quality metrics across all platforms, exposing call quality events and warnings via the plugin API and updating the example app and documentation to demonstrate their use. It includes native implementation for Android and iOS, updates the Dart platform interface, and ensures call quality state is handled correctly throughout the call lifecycle.

**Call Quality Metrics Support:**

* Added a `CallQualityEvent` model and exposed a `qualityWarnings` stream and `lastQualityWarnings` getter on `TwilioCallPlatform`, allowing clients to observe call quality warnings in real time. [[1]](diffhunk://#diff-3ac868249404f077fde0a0bdcafd8b516c3c1c2bfa3b0cc979854551e02ad04bR5-R17) [[2]](diffhunk://#diff-3ac868249404f077fde0a0bdcafd8b516c3c1c2bfa3b0cc979854551e02ad04bR88-R93) [[3]](diffhunk://#diff-41b784d394759a289d0c1128c8ac01b9090b2aee0d7e233a498a79d3cec3b411R21-R31) [[4]](diffhunk://#diff-41b784d394759a289d0c1128c8ac01b9090b2aee0d7e233a498a79d3cec3b411R139-R157)
* Implemented native event handling for call quality warnings on Android (`onCallQualityWarningsChanged` in `TVCallConnection`, new event and extras, and event channel integration) and iOS (`callDidReceiveQualityWarnings` in `SwiftTwilioVoicePlugin`). [[1]](diffhunk://#diff-edf07e994ffbcb227c25d48701f3fb2111bb8d359c0c9f6a342e5e8761a20143R267-R301) [[2]](diffhunk://#diff-bdd4abc8b1538c3e31d0ee2ae8c43fbec1c486cb517fa9c475785e56bea10435R45-R49) [[3]](diffhunk://#diff-c61150800d795e611f19ff64bc5f3695204cae63d888a2d0f2b127f7dfa92ae8R54-R65) [[4]](diffhunk://#diff-cd8db83ca5629b36aee8f06cc66647fd892275a6b495af68bcb5915a85858f37R1476) [[5]](diffhunk://#diff-cd8db83ca5629b36aee8f06cc66647fd892275a6b495af68bcb5915a85858f37R2018-R2023) [[6]](diffhunk://#diff-dcc6535a9a0005d0fa59b345bcebdc26a06a66a5505e3b69ecf3c948baedb0daR818-R839)
* Updated the method channel implementation to parse and dispatch quality warning events, and to clear quality state when a call ends or is declined. [[1]](diffhunk://#diff-a9ba6296b92dfa32f726b72d4898fe4c2fac7705ecf47cdc6b269538352c5ed1R328-R338) [[2]](diffhunk://#diff-a9ba6296b92dfa32f726b72d4898fe4c2fac7705ecf47cdc6b269538352c5ed1R369-R384) [[3]](diffhunk://#diff-a9ba6296b92dfa32f726b72d4898fe4c2fac7705ecf47cdc6b269538352c5ed1R437-R440)

**Documentation and Example Updates:**

* Updated `README.md` and `CHANGELOG.md` to document the new call quality metrics feature and provide usage examples. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R27) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R580-R600)
* Enhanced the example app UI to display live call quality status using the new API. [[1]](diffhunk://#diff-091df52e09bfd40d4cab7cb0b07753a158fb6b08dbb5f9aaf861b823a46cb32dL55-R55) [[2]](diffhunk://#diff-091df52e09bfd40d4cab7cb0b07753a158fb6b08dbb5f9aaf861b823a46cb32dR71) [[3]](diffhunk://#diff-091df52e09bfd40d4cab7cb0b07753a158fb6b08dbb5f9aaf861b823a46cb32dR136-R160)

**Other:**

* Minor build and dependency updates for the example app (e.g., adding `com.google.gms.google-services` plugin). [[1]](diffhunk://#diff-39ab2ed24002fb8e39b9db8ebac35907f77395dbc3c2faf95e6e6b6805e0b9ceR3) [[2]](diffhunk://#diff-7f54936aa905acbc0747155c99716ec8093d541903fea73736db05fc0f729a1dR22)