### PR TITLE
fix: crash on incoming call while unmarshalling `CallInvite` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * feat: [iOS, macOS] Swift Package Manager support added, enable it with `flutter config --enable-swift-package-manager`. _Note: projects using CocoaPods will continue to use CocoaPods, and SPM is only used for new projects or those that have opted in._
 * feat: added call quality events for all platforms (see `CallQualityEvent` and `TwilioVoicePlatform.instance.call.qualityWarnings`, and [Twilio Call Quality Metrics](https://www.twilio.com/docs/voice/voice-insights/api/call/details-sdk-call-quality-events#error-and-warning-events))
+* fix: [android] fixed crash when `CallInvite` is received due to unmarshalling error with some Telecom/ConnectionService implementations (e.g. Samsung)
 * Updated Example
 * Updated docs
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip

--- a/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
@@ -53,6 +53,13 @@ class TVConnectionService : ConnectionService() {
          */
         private val pendingCallInvites = HashMap<String, CallInvite>()
 
+        /**
+         * SIDs of invites cancelled before Telecom got round to creating their Connection.
+         */
+        private val cancelledCallInvites = LinkedHashSet<String>()
+
+        private const val MAX_CANCELLED_CALL_INVITES = 32
+
         val TWI_SCHEME: String = "twi"
 
         /**
@@ -287,8 +294,16 @@ class TVConnectionService : ConnectionService() {
 
                     val callHandle = cancelledCallInvite.callSid
                     val connection = getConnection(callHandle) as? TVCallInviteConnection
+                    pendingCallInvites.remove(callHandle)
+
                     if (connection == null) {
-                        Log.e(TAG, "onStartCommand: [ACTION_CANCEL_CALL_INVITE] could not find incoming connection for callHandle: $callHandle")
+                        Log.w(TAG, "onStartCommand: [ACTION_CANCEL_CALL_INVITE] no connection yet for callHandle: $callHandle, cancelling the pending one")
+                        // The Connection is still in flight; mark it so onCreateIncomingConnection
+                        // does not raise a call the caller has already given up on.
+                        if (cancelledCallInvites.size >= MAX_CANCELLED_CALL_INVITES) {
+                            cancelledCallInvites.iterator().let { i -> i.next(); i.remove() }
+                        }
+                        cancelledCallInvites.add(callHandle)
                     } else {
                         val errorCode = it.getIntExtra(EXTRA_CANCEL_CALL_INVITE_ERROR_CODE, NO_ERROR_CODE)
 
@@ -568,6 +583,20 @@ class TVConnectionService : ConnectionService() {
         val callSid: String = myBundle.getString(EXTRA_INCOMING_CALL_SID) ?: run {
             Log.e(TAG, "onCreateIncomingConnection: request is missing EXTRA_INCOMING_CALL_SID")
             throw Exception("onCreateIncomingConnection: request is missing EXTRA_INCOMING_CALL_SID");
+        }
+
+        // The caller hung up while this Connection was still being created - report it as missed
+        // rather than ringing a call that no longer exists.
+        if (cancelledCallInvites.remove(callSid)) {
+            Log.i(TAG, "onCreateIncomingConnection: invite '$callSid' was cancelled before the connection was created")
+            pendingCallInvites.remove(callSid)
+            onConnectionEnded(null)
+            // MISSED makes the platform log a missed call; CANCELED suppresses it - matching
+            // TVCallInviteConnection.reportMissedCall's handling of the showNotifications setting.
+            val showNotifications: Boolean = StorageImpl(applicationContext).showNotifications
+            return Connection.createFailedConnection(
+                DisconnectCause(if (showNotifications) DisconnectCause.MISSED else DisconnectCause.CANCELED)
+            )
         }
 
         // Claim the invite held for this SID; removing it keeps the map from growing if a call is

--- a/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
@@ -284,7 +284,7 @@ class TVConnectionService : ConnectionService() {
 
                     // Load CancelledCallInvite class loader
                     // See: https://github.com/twilio/voice-quickstart-android/issues/561#issuecomment-1678613170
-                    it.setExtrasClassLoader(CallInvite::class.java.classLoader)
+                    it.setExtrasClassLoader(CancelledCallInvite::class.java.classLoader)
                     val cancelledCallInvite = it.getParcelableExtraSafe<CancelledCallInvite>(EXTRA_CANCEL_CALL_INVITE) ?: run {
                         Log.e(TAG, "onStartCommand: ACTION_CANCEL_CALL_INVITE is missing parcelable EXTRA_CANCEL_CALL_INVITE")
                                 // Tear down the foreground service we just started if nothing else is running.

--- a/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
@@ -47,6 +47,12 @@ class TVConnectionService : ConnectionService() {
 
         val activeConnections = HashMap<String, TVCallConnection>()
 
+        /**
+         * Pending [CallInvite]s awaiting a Connection, mapped to Call SID. CallInvites are accepted
+         * in [onCreateIncomingConnection] or if failed removed by [onCreateIncomingConnectionFailed].
+         */
+        private val pendingCallInvites = HashMap<String, CallInvite>()
+
         val TWI_SCHEME: String = "twi"
 
         /**
@@ -55,12 +61,6 @@ class TVConnectionService : ConnectionService() {
         const val FOREGROUND_NOTIFICATION_ID: Int = 100
 
         val SERVICE_TYPE_MICROPHONE: Int = FOREGROUND_NOTIFICATION_ID
-
-        //region ACTIONS_* Constants
-        /**
-         * Action used with [VoiceFirebaseMessagingService] to notify of incoming calls
-         */
-        const val ACTION_CALL_INVITE: String = "ACTION_CALL_INVITE"
 
         //region ACTIONS_* Constants
         /**
@@ -138,6 +138,12 @@ class TVConnectionService : ConnectionService() {
          * Extra used with [ACTION_CANCEL_CALL_INVITE] to cancel a call connection.
          */
         const val EXTRA_INCOMING_CALL_INVITE: String = "EXTRA_INCOMING_CALL_INVITE"
+
+        /**
+         * Call SID handed to Telecom in place of the [CallInvite]. A String is safe for any process
+         * to unmarshal - see [pendingCallInvites].
+         */
+        const val EXTRA_INCOMING_CALL_SID: String = "EXTRA_INCOMING_CALL_SID"
 
         /**
          * Extra used to identify a call connection.
@@ -342,10 +348,10 @@ class TVConnectionService : ConnectionService() {
                         return@let
                     }
 
+                    pendingCallInvites[callInvite.callSid] = callInvite
                     val myBundle: Bundle = Bundle().apply {
-                        putParcelable(EXTRA_INCOMING_CALL_INVITE, callInvite)
+                        putString(EXTRA_INCOMING_CALL_SID, callInvite.callSid)
                     }
-                    myBundle.classLoader = CallInvite::class.java.classLoader
 
                     // Add extras for [addNewIncomingCall] method
                     val extras = Bundle().apply {
@@ -559,10 +565,16 @@ class TVConnectionService : ConnectionService() {
             throw Exception("onCreateIncomingConnection: request is missing Bundle EXTRA_INCOMING_CALL_EXTRAS");
         }
 
-        myBundle.classLoader = CallInvite::class.java.classLoader
-        val ci: CallInvite = myBundle.getParcelableSafe(EXTRA_INCOMING_CALL_INVITE) ?: run {
-            Log.e(TAG, "onCreateIncomingConnection: request is missing CallInvite EXTRA_INCOMING_CALL_INVITE")
-            throw Exception("onCreateIncomingConnection: request is missing CallInvite EXTRA_INCOMING_CALL_INVITE");
+        val callSid: String = myBundle.getString(EXTRA_INCOMING_CALL_SID) ?: run {
+            Log.e(TAG, "onCreateIncomingConnection: request is missing EXTRA_INCOMING_CALL_SID")
+            throw Exception("onCreateIncomingConnection: request is missing EXTRA_INCOMING_CALL_SID");
+        }
+
+        // Claim the invite held for this SID; removing it keeps the map from growing if a call is
+        // never connected.
+        val ci: CallInvite = pendingCallInvites.remove(callSid) ?: run {
+            Log.e(TAG, "onCreateIncomingConnection: no pending CallInvite for SID '$callSid'")
+            throw Exception("onCreateIncomingConnection: no pending CallInvite for SID '$callSid'");
         }
 
         // Create storage instance for call parameters
@@ -574,7 +586,8 @@ class TVConnectionService : ConnectionService() {
         // Create connection
         val connection = TVCallInviteConnection(applicationContext, ci, callParams)
 
-        // Remove call invite from extras, causes marshalling error i.e. Class not found.
+        // The nested bundle has served its purpose; drop it rather than publishing plugin-internal
+        // extras to every InCallService.
         val requestBundle = request.extras.also { it ->
             it.remove(TelecomManager.EXTRA_INCOMING_CALL_EXTRAS)
         }
@@ -803,6 +816,12 @@ class TVConnectionService : ConnectionService() {
     override fun onCreateIncomingConnectionFailed(connectionManagerPhoneAccount: PhoneAccountHandle?, request: ConnectionRequest?) {
         super.onCreateIncomingConnectionFailed(connectionManagerPhoneAccount, request)
         Log.d(TAG, "onCreateIncomingConnectionFailed")
+
+        // No Connection will claim the invite held for this call, so release it here.
+        request?.extras
+            ?.getBundle(TelecomManager.EXTRA_INCOMING_CALL_EXTRAS)
+            ?.getString(EXTRA_INCOMING_CALL_SID)
+            ?.let { pendingCallInvites.remove(it) }
         // The failed connection was never added to activeConnections; only demote the
         // service if no other call is active.
         onConnectionEnded(null)


### PR DESCRIPTION
This pull request addresses a critical crash on Android devices when receiving a `CallInvite`, caused by unmarshalling errors in some Telecom/ConnectionService implementations (notably on Samsung devices). The solution avoids passing complex `CallInvite` objects between processes by instead using call SIDs (simple strings), and manages pending and cancelled invites more robustly. It also updates the Gradle wrapper version.

**Android Crash Fixes and Call Handling Improvements:**

- **Fix crash due to unmarshalling error with `CallInvite`:**
  - Instead of passing the `CallInvite` object via Bundles (which caused ClassNotFound exceptions in some environments), the code now passes only the call SID (`String`) and manages the actual `CallInvite` objects in a local map (`pendingCallInvites`). This prevents marshalling issues and ensures safer cross-process communication. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5) [[2]](diffhunk://#diff-b939af2345bc2785c2f16f91ea6be6419cc87f49353c7207689b0ab0c3a9b225R50-R62) [[3]](diffhunk://#diff-b939af2345bc2785c2f16f91ea6be6419cc87f49353c7207689b0ab0c3a9b225R149-R154) [[4]](diffhunk://#diff-b939af2345bc2785c2f16f91ea6be6419cc87f49353c7207689b0ab0c3a9b225R366-L348) [[5]](diffhunk://#diff-b939af2345bc2785c2f16f91ea6be6419cc87f49353c7207689b0ab0c3a9b225L562-R606) [[6]](diffhunk://#diff-b939af2345bc2785c2f16f91ea6be6419cc87f49353c7207689b0ab0c3a9b225L577-R619)
  - Cancelled invites are tracked in a new `cancelledCallInvites` set, ensuring that invites cancelled before a connection is created are handled gracefully and do not result in ringing or missed calls being incorrectly reported. [[1]](diffhunk://#diff-b939af2345bc2785c2f16f91ea6be6419cc87f49353c7207689b0ab0c3a9b225R50-R62) [[2]](diffhunk://#diff-b939af2345bc2785c2f16f91ea6be6419cc87f49353c7207689b0ab0c3a9b225R297-R306) [[3]](diffhunk://#diff-b939af2345bc2785c2f16f91ea6be6419cc87f49353c7207689b0ab0c3a9b225L562-R606)
  - Pending invites are properly cleaned up if connection creation fails, preventing leaks.

**Dependency Upgrades:**

- **Gradle Wrapper Update:**
  - The Gradle wrapper is updated from version 8.8 to 8.11.1 for improved build reliability and compatibility.

**Code Maintenance:**

- **Refactoring and Documentation:**
  - Improved comments and documentation for new fields and logic related to pending/cancelled invites. [[1]](diffhunk://#diff-b939af2345bc2785c2f16f91ea6be6419cc87f49353c7207689b0ab0c3a9b225R50-R62) [[2]](diffhunk://#diff-b939af2345bc2785c2f16f91ea6be6419cc87f49353c7207689b0ab0c3a9b225R149-R154)
  - Removal of unused constants and redundant class loader assignments. [[1]](diffhunk://#diff-b939af2345bc2785c2f16f91ea6be6419cc87f49353c7207689b0ab0c3a9b225L59-L64) [[2]](diffhunk://#diff-b939af2345bc2785c2f16f91ea6be6419cc87f49353c7207689b0ab0c3a9b225L274-R287)

These changes significantly improve Android call invite handling stability and reliability, especially on devices with custom Telecom implementations.