### PR TITLE
fix: remove UI hanging when answering call on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next Release
 
+* fix: [Android] `setActive()` now proactively changes call UI to ongoing call screen when answering incoming call preventing perceived delay while connecting.
 * feat: [iOS, macOS] Swift Package Manager support added, enable it with `flutter config --enable-swift-package-manager`. _Note: projects using CocoaPods will continue to use CocoaPods, and SPM is only used for new projects or those that have opted in._
 * feat: added call quality events for all platforms (see `CallQualityEvent` and `TwilioVoicePlatform.instance.call.qualityWarnings`, and [Twilio Call Quality Metrics](https://www.twilio.com/docs/voice/voice-insights/api/call/details-sdk-call-quality-events#error-and-warning-events))
 * fix: [android] fixed crash when `CallInvite` is received due to unmarshalling error with some Telecom/ConnectionService implementations (e.g. Samsung)

--- a/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnection.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnection.kt
@@ -48,6 +48,7 @@ class TVCallInviteConnection(
     override fun onAnswer() {
         Log.d(TAG, "onAnswer: onAnswer")
         super.onAnswer()
+        setActive()
         twilioCall = callInvite.accept(context, this)
         onAction?.onChange(TVNativeCallActions.ACTION_ANSWERED, Bundle().apply {
             putParcelable(TVBroadcastReceiver.EXTRA_CALL_INVITE, callInvite)

--- a/example/lib/screens/ui_call_screen.dart
+++ b/example/lib/screens/ui_call_screen.dart
@@ -51,78 +51,78 @@ class _UICallScreenState extends State<UICallScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: <Widget>[
-        TextFormField(
-          key: _identifierKey,
-          controller: _controller,
-          validator: (value) {
-            if (value == null || value.isEmpty) {
-              return "Please enter a client identifier";
-            }
-            return null;
-          },
-          decoration: const InputDecoration(labelText: 'Client Identifier or Phone Number'),
-        ),
-        const SizedBox(height: 10),
-        Wrap(
-          children: [
-            Text("My Identity: ${widget.userId}"),
-            const SizedBox(width: 8),
-            GestureDetector(
-              onTap: () => _copyToClipboard(widget.userId),
-              child: _copied ? const Icon(Icons.check, color: Colors.green, size: 16) : const Icon(Icons.copy, size: 16),
-            ),
-          ],
-        ),
-        const SizedBox(height: 10),
-        CallActions(
-          canCall: true,
-          onPerformCall: () {
-            final identifier = _identifierKey.currentState?.value;
-            if (identifier != null && identifier.isNotEmpty) {
-              widget.onPerformCall(identifier);
-            }
-          },
-        ),
-        const SizedBox(height: 10),
-        const Card(
-          child: Padding(
-            padding: EdgeInsets.all(8.0),
-            child: CallStatus(),
+    return SingleChildScrollView(
+      child: Column(
+        children: <Widget>[
+          TextFormField(
+            key: _identifierKey,
+            controller: _controller,
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return "Please enter a client identifier";
+              }
+              return null;
+            },
+            decoration: const InputDecoration(labelText: 'Client Identifier or Phone Number'),
           ),
-        ),
-        const Card(
-          child: Padding(
-            padding: EdgeInsets.all(8.0),
-            child: CallControls(),
-          ),
-        ),
-        ListTile(
-          title: const Text("Permissions"),
-          subtitle: const Text("Please allow all permissions to use the app"),
-          trailing: const Icon(Icons.arrow_forward_ios),
-          onTap: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (context) => const UiPermissionsScreen(),
+          const SizedBox(height: 10),
+          Wrap(
+            children: [
+              Text("My Identity: ${widget.userId}"),
+              const SizedBox(width: 8),
+              GestureDetector(
+                onTap: () => _copyToClipboard(widget.userId),
+                child: _copied ? const Icon(Icons.check, color: Colors.green, size: 16) : const Icon(Icons.copy, size: 16),
               ),
-            );
-          },
-        ),
-        const Divider(),
-        const _RingSound(),
-        const Divider(),
-        Expanded(
-          child: Column(
+            ],
+          ),
+          const SizedBox(height: 10),
+          CallActions(
+            canCall: true,
+            onPerformCall: () {
+              final identifier = _identifierKey.currentState?.value;
+              if (identifier != null && identifier.isNotEmpty) {
+                widget.onPerformCall(identifier);
+              }
+            },
+          ),
+          const SizedBox(height: 10),
+          const Card(
+            child: Padding(
+              padding: EdgeInsets.all(8.0),
+              child: CallStatus(),
+            ),
+          ),
+          const Card(
+            child: Padding(
+              padding: EdgeInsets.all(8.0),
+              child: CallControls(),
+            ),
+          ),
+          ListTile(
+            title: const Text("Permissions"),
+            subtitle: const Text("Please allow all permissions to use the app"),
+            trailing: const Icon(Icons.arrow_forward_ios),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => const UiPermissionsScreen(),
+                ),
+              );
+            },
+          ),
+          const Divider(),
+          const _RingSound(),
+          const Divider(),
+          Column(
             children: [
               Text("Events (latest at top)", style: Theme.of(context).textTheme.titleLarge),
               const TwilioLog(),
             ],
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
This pull request focuses on improving the user experience when answering incoming calls on Android and enhancing the UI flexibility in the example app. The most important changes are grouped below:

Android Call Handling:

* The `setActive()` method is now called proactively in `TVCallInviteConnection.onAnswer()`, ensuring the call UI transitions immediately to the ongoing call screen when answering an incoming call. This prevents any perceived delay while the connection is established. [[1]](diffhunk://#diff-edf07e994ffbcb227c25d48701f3fb2111bb8d359c0c9f6a342e5e8761a20143R51) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3)

Example App UI Improvements:

* The main call screen widget in `ui_call_screen.dart` now uses a `SingleChildScrollView` instead of a plain `Column`, allowing the UI to be scrollable and preventing overflow issues on smaller screens.
* The events log section is no longer wrapped in an `Expanded` widget, which improves layout flexibility within the scrollable context.