### PR TITLE
fix: update ongoing call in plugin on cold start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next Release
 
+* fix: [Android, iOS, macOS] `isOnCall` & `activeCall` now sync. Launching app with ongoing call now returns correct `activeCall` object and `isOnCall` true. (see [Issue #179](https://github.com/cybex-dev/twilio_voice/issues/179))
 * feat: [iOS, macOS] Swift Package Manager support added, enable it with `flutter config --enable-swift-package-manager`. _Note: projects using CocoaPods will continue to use CocoaPods, and SPM is only used for new projects or those that have opted in._
 * feat: added call quality events for all platforms (see `CallQualityEvent` and `TwilioVoicePlatform.instance.call.qualityWarnings`, and [Twilio Call Quality Metrics](https://www.twilio.com/docs/voice/voice-insights/api/call/details-sdk-call-quality-events#error-and-warning-events))
 * fix: [android] fixed crash when `CallInvite` is received due to unmarshalling error with some Telecom/ConnectionService implementations (e.g. Samsung)

--- a/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
@@ -12,6 +12,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.telecom.CallAudioState
+import android.telecom.Connection
 import android.telecom.PhoneAccountHandle
 import android.telecom.TelecomManager
 import android.util.Log
@@ -97,6 +98,10 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
     /// events are discarded first. Accessed only on the main thread.
     private val pendingEvents = ArrayDeque<String>()
     private val maxPendingEvents = 50
+
+    /// Event prefixes that describe call state, used to tell whether the buffered events already
+    /// told Dart about the call in progress.
+    private val CALL_STATE_EVENT_PREFIXES = arrayOf("Incoming", "Ringing", "Answer", "Connected")
 
     // member instance functions
     private var callListener = callListener()
@@ -340,13 +345,64 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
     override fun onListen(arguments: Any?, events: EventSink?) {
         Log.i(TAG, "Setting event sink")
         this.eventSink = events
+        if (events == null) return
+
         // Flush events buffered before the listener attached (e.g. an incoming call that
         // arrived during a cold start, before Dart subscribed).
-        if (events != null && pendingEvents.isNotEmpty()) {
+        var buffered = emptyList<String>()
+        if (pendingEvents.isNotEmpty()) {
             Log.i(TAG, "Flushing ${pendingEvents.size} buffered event(s)")
-            val buffered = pendingEvents.toList()
+            buffered = pendingEvents.toList()
             pendingEvents.clear()
             buffered.forEach { events.success(it) }
+        }
+
+        if (buffered.none { it.isCallStateEvent() }) {
+            emitActiveCallState()
+        }
+    }
+
+    /// Whether this event describes the state of a call, as opposed to a log or permission event.
+    private fun String.isCallStateEvent(): Boolean =
+        CALL_STATE_EVENT_PREFIXES.any { startsWith("$it|") }
+
+    /**
+     * Emits the current state of the call [TVConnectionService] is holding, if any.
+     */
+    private fun emitActiveCallState() {
+        val handle = TVConnectionService.getActiveCallHandle() ?: return
+        val connection = TVConnectionService.getConnection(handle) ?: return
+        val params = connection.getCallParameters() ?: run {
+            Log.w(TAG, "emitActiveCallState: connection '$handle' has no call parameters yet")
+            return
+        }
+
+        val from = params.fromRaw
+        val to = params.toRaw
+        val direction = connection.callDirection.label
+        val customParams = JSONObject().apply {
+            params.customParameters.forEach { (key, value) -> put(key, value) }
+        }.toString()
+
+        when (connection.state) {
+            Connection.STATE_RINGING -> {
+                Log.i(TAG, "Emitting state of ringing call '$handle' for the new listener")
+                logEvents("", arrayOf("Incoming", from, to, direction, customParams))
+            }
+
+            Connection.STATE_ACTIVE, Connection.STATE_HOLDING -> {
+                Log.i(TAG, "Emitting state of active call '$handle' for the new listener")
+                logEvents("", arrayOf("Connected", from, to, direction, customParams))
+
+                if (connection.state == Connection.STATE_HOLDING) {
+                    logEvents("", arrayOf("Hold"))
+                }
+                if (connection.twilioCall?.state == Call.State.RECONNECTING) {
+                    logEvents("", arrayOf("Reconnecting"))
+                }
+            }
+
+            else -> Log.d(TAG, "emitActiveCallState: nothing to emit for state ${connection.state}")
         }
     }
 
@@ -1557,6 +1613,9 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
         val sink = eventSink
         if (sink == null) {
             // Buffer until the Dart listener attaches (see pendingEvents / onListen).
+            if (message.isCallStateEvent()) {
+                pendingEvents.removeAll { it.isCallStateEvent() }
+            }
             if (pendingEvents.size >= maxPendingEvents) {
                 pendingEvents.removeFirst()
             }

--- a/ios/twilio_voice/Sources/twilio_voice/SwiftTwilioVoicePlugin.swift
+++ b/ios/twilio_voice/Sources/twilio_voice/SwiftTwilioVoicePlugin.swift
@@ -62,6 +62,9 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         callStateEventPrefixes.contains(where: message.hasPrefix)
     }
 
+    /// Custom parameters of the call in progress.
+    private var customParameters: [String: Any]?
+
     var callKitCompletionCallback: ((Bool)->Swift.Void?)? = nil
     var audioDevice: DefaultAudioDevice = DefaultAudioDevice()
     
@@ -736,6 +739,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         self.sendPhoneCallEvents(description: "Ringing|\(from)|\(callInvite.to)|Incoming\(formatCustomParams(params: callInvite.customParameters))", isError: false)
         reportIncomingCall(from: from, uuid: callInvite.uuid)
         self.callInvite = callInvite
+        self.customParameters = callInvite.customParameters
     }
     
     func formatCustomParams(params: [String:Any]?)->String{
@@ -910,6 +914,8 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         if (self.callInvite != nil) {
             self.callInvite = nil
         }
+        self.customParameters = nil
+        self.callArgs = [String: AnyObject]()
 
         self.callOutgoing = false
         self.userInitiatedDisconnect = false
@@ -1024,6 +1030,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
             self.sendPhoneCallEvents(description: "LOG|provider:performEndCallAction: rejecting call", isError: false)
             self.callInvite?.reject()
             self.callInvite = nil
+            self.customParameters = nil
         }else if let call = self.call {
             self.sendPhoneCallEvents(description: "LOG|provider:performEndCallAction: disconnecting call", isError: false)
             call.disconnect()
@@ -1177,6 +1184,9 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         }
         let theCall = TwilioVoiceSDK.connect(options: connectOptions, delegate: self)
         self.call = theCall
+        self.customParameters = self.callArgs
+            .filter { $0.key != "accessToken" }
+            .mapValues { $0 as Any }
         self.callKitCompletionCallback = completionHandler
     }
     
@@ -1242,7 +1252,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
             let from = (activeCall.from ?? self.identity).replacingOccurrences(of: "client:", with: "")
             let to = activeCall.to ?? self.callTo
             NSLog("Emitting state of active call for the new listener")
-            self.sendPhoneCallEvents(description: "Connected|\(from)|\(to)|\(direction)", isError: false)
+            self.sendPhoneCallEvents(description: "Connected|\(from)|\(to)|\(direction)\(formatCustomParams(params: self.customParameters))", isError: false)
 
             if activeCall.isOnHold {
                 self.sendPhoneCallEvents(description: "Hold", isError: false)

--- a/ios/twilio_voice/Sources/twilio_voice/SwiftTwilioVoicePlugin.swift
+++ b/ios/twilio_voice/Sources/twilio_voice/SwiftTwilioVoicePlugin.swift
@@ -743,9 +743,9 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
     }
     
     func formatCustomParams(params: [String:Any]?)->String{
-        guard let customParameters = params else{return ""}
+        guard let map = params else{return ""}
         do{
-            let jsonData = try JSONSerialization.data(withJSONObject: customParameters)
+            let jsonData = try JSONSerialization.data(withJSONObject: map)
             if let jsonStr = String(data: jsonData, encoding: .utf8){
                 return "|\(jsonStr )"
             }
@@ -1266,7 +1266,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
             self.sendPhoneCallEvents(description: "Incoming|\(from)|\(invite.to)|Incoming\(formatCustomParams(params: invite.customParameters))", isError: false)
         }
     }
-    
+
     private func sendPhoneCallEvents(description: String, isError: Bool) {
         NSLog(description)
         

--- a/ios/twilio_voice/Sources/twilio_voice/SwiftTwilioVoicePlugin.swift
+++ b/ios/twilio_voice/Sources/twilio_voice/SwiftTwilioVoicePlugin.swift
@@ -47,6 +47,21 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
     
     var callInvite:CallInvite?
     var call:Call?
+
+    /// Events raised before the Dart listener attached, held here and flushed in `onListen` rather
+    /// than being dropped. Bounded so a long-running app cannot grow this without limit.
+    private var pendingEvents: [String] = []
+    private let maxPendingEvents = 50
+
+    /// Event prefixes that describe call state, used to tell whether the buffered events already
+    /// told Dart about the call in progress.
+    private let callStateEventPrefixes = ["Incoming|", "Ringing|", "Answer|", "Connected|"]
+
+    /// Whether this event describes the state of a call, as opposed to a log or status flag.
+    private func isCallStateEvent(_ message: String) -> Bool {
+        callStateEventPrefixes.contains(where: message.hasPrefix)
+    }
+
     var callKitCompletionCallback: ((Bool)->Swift.Void?)? = nil
     var audioDevice: DefaultAudioDevice = DefaultAudioDevice()
     
@@ -1190,6 +1205,20 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
     public func onListen(withArguments arguments: Any?,
                          eventSink: @escaping FlutterEventSink) -> FlutterError? {
         self.eventSink = eventSink
+
+        // Deliver anything raised before Dart subscribed (see sendEvent).
+        let buffered = pendingEvents
+        if !buffered.isEmpty {
+            NSLog("Flushing \(buffered.count) buffered event(s)")
+            pendingEvents.removeAll()
+            DispatchQueue.main.async {
+                buffered.forEach { eventSink($0) }
+            }
+        }
+
+        if !buffered.contains(where: isCallStateEvent) {
+            emitActiveCallState()
+        }
         
         NotificationCenter.default.addObserver(
             self,
@@ -1204,6 +1233,28 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         NotificationCenter.default.removeObserver(self)
         eventSink = nil
         return nil
+    }
+    
+    /// Emits the current state of the call in progress, if any.
+    private func emitActiveCallState() {
+        if let activeCall = self.call, activeCall.state == .connected || activeCall.state == .reconnecting {
+            let direction = self.callOutgoing ? "Outgoing" : "Incoming"
+            let from = (activeCall.from ?? self.identity).replacingOccurrences(of: "client:", with: "")
+            let to = activeCall.to ?? self.callTo
+            NSLog("Emitting state of active call for the new listener")
+            self.sendPhoneCallEvents(description: "Connected|\(from)|\(to)|\(direction)", isError: false)
+
+            if activeCall.isOnHold {
+                self.sendPhoneCallEvents(description: "Hold", isError: false)
+            }
+            if activeCall.state == .reconnecting {
+                self.sendPhoneCallEvents(description: "Reconnecting", isError: false)
+            }
+        } else if let invite = self.callInvite {
+            let from = (invite.from ?? self.defaultCaller).replacingOccurrences(of: "client:", with: "")
+            NSLog("Emitting state of ringing call for the new listener")
+            self.sendPhoneCallEvents(description: "Incoming|\(from)|\(invite.to)|Incoming\(formatCustomParams(params: invite.customParameters))", isError: false)
+        }
     }
     
     private func sendPhoneCallEvents(description: String, isError: Bool) {
@@ -1222,6 +1273,15 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
     
     private func sendEvent(_ event: Any) {
         guard let eventSink = eventSink else {
+            if let message = event as? String {
+                if isCallStateEvent(message) {
+                    pendingEvents.removeAll(where: isCallStateEvent)
+                }
+                if pendingEvents.count >= maxPendingEvents {
+                    pendingEvents.removeFirst()
+                }
+                pendingEvents.append(message)
+            }
             return
         }
         DispatchQueue.main.async {

--- a/macos/twilio_voice/Sources/twilio_voice/TwilioVoicePlugin.swift
+++ b/macos/twilio_voice/Sources/twilio_voice/TwilioVoicePlugin.swift
@@ -25,6 +25,20 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
 //    private var _result: FlutterResult?
     private var eventSink: FlutterEventSink?
 
+    /// Events raised before the Dart listener attached, held here and flushed in `onListen` rather
+    /// than being dropped. Bounded so a long-running app cannot grow this without limit.
+    private var pendingEvents: [String] = []
+    private let maxPendingEvents = 50
+
+    /// Event prefixes that describe call state, used to tell whether the buffered events already
+    /// told Dart about the call in progress.
+    private let callStateEventPrefixes = ["Incoming|", "Ringing|", "Answer|", "Connected|"]
+
+    /// Whether this event describes the state of a call, as opposed to a log or status flag.
+    private func isCallStateEvent(_ message: String) -> Bool {
+        callStateEventPrefixes.contains(where: message.hasPrefix)
+    }
+
     let kCachedDeviceToken = "CachedDeviceToken"
     let kCachedBindingDate = "CachedBindingDate"
     let kClientList = "TwilioContactList"
@@ -1103,6 +1117,18 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
     public func onListen(withArguments arguments: Any?, eventSink: @escaping FlutterEventSink) -> FlutterError? {
         self.eventSink = eventSink
 
+        // Deliver anything raised before Dart subscribed (see logEvent).
+        let buffered = pendingEvents
+        if !buffered.isEmpty {
+            NSLog("Flushing \(buffered.count) buffered event(s)")
+            pendingEvents.removeAll()
+            onMain { buffered.forEach { eventSink($0) } }
+        }
+
+        if !buffered.contains(where: isCallStateEvent) {
+            emitActiveCallState()
+        }
+
         // TODO - review
         //        NotificationCenter.default.addObserver(
         //            self,
@@ -1147,6 +1173,16 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
     private func logEvent(prefix: String = "LOG", separator: String = "|", description: String, isError: Bool = false) {
         NSLog(description)
         guard let eventSink = eventSink else {
+            if !isError {
+                let message = buildMessage(prefix: prefix, separator: separator, description: description)
+                if isCallStateEvent(message) {
+                    pendingEvents.removeAll(where: isCallStateEvent)
+                }
+                if pendingEvents.count >= maxPendingEvents {
+                    pendingEvents.removeFirst()
+                }
+                pendingEvents.append(message)
+            }
             return
         }
 
@@ -1154,14 +1190,52 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
             let flutterError = FlutterError(code: FlutterErrorCodes.UNAVAILABLE_ERROR, message: description, details: nil)
             onMain { eventSink(flutterError) }
         } else {
-            var message = "";
-            if (prefix.isEmpty) {
-                message = description;
-            } else {
-                message = prefix + separator + description;
-            }
+            onMain { eventSink(self.buildMessage(prefix: prefix, separator: separator, description: description)) }
+        }
+    }
 
-            onMain { eventSink(message) }
+    /// Builds the wire message sent over the event channel: `<prefix><separator><description>`, or
+    /// just the description when there is no prefix (call state events carry no prefix).
+    private func buildMessage(prefix: String, separator: String, description: String) -> String {
+        prefix.isEmpty ? description : prefix + separator + description
+    }
+
+    /// Emits the current state of the call in progress, if any.
+    private func emitActiveCallState() {
+        guard let activeCall = twilioCall else { return }
+
+        activeCall.status { [weak self] status, _ in
+            guard let self = self, let status = status else { return }
+            activeCall.resolveParams { params, _ in
+                activeCall.direction { direction, _ in
+                    let from = params?.from ?? ""
+                    let to = params?.to ?? ""
+                    let customParams = self.formatCustomParams(params: params?.customParameters)
+
+                    switch status {
+                    case .pending, .ringing:
+                        NSLog("Emitting state of ringing call for the new listener")
+                        self.logEvents(prefix: "", descriptions: ["Incoming", from, to, "Incoming", customParams])
+
+                    case .open, .connected, .reconnecting, .reconnected:
+                        NSLog("Emitting state of active call for the new listener")
+                        self.logEvents(prefix: "", descriptions: [
+                            "Connected",
+                            from,
+                            to,
+                            (direction ?? .outgoing).rawValue.capitalized,
+                            customParams,
+                        ])
+
+                        if status == .reconnecting {
+                            self.logEvents(prefix: "", descriptions: ["Reconnecting"])
+                        }
+
+                    default:
+                        NSLog("Nothing to emit for call status '\(status.rawValue)'")
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This pull request addresses a longstanding issue with the synchronization of call state between the native layers and Dart, ensuring that the `activeCall` object and `isOnCall` flag are always accurate when launching the app with an ongoing call. It introduces robust event buffering and replay mechanisms for Android, iOS, and macOS, so that the Dart side receives the correct call state even if the listener attaches after a call is already in progress. Additionally, the event buffer is now bounded to prevent unbounded memory growth.

The most important changes are:

**Call State Synchronization and Event Replay**

* When the Dart event listener attaches, if no call state event was buffered, the native layer emits the current call state (`activeCall` and `isOnCall`) to ensure Dart is immediately up-to-date, even if the app was launched or resumed during an ongoing call. This applies to Android, iOS, and macOS. [[1]](diffhunk://#diff-cd8db83ca5629b36aee8f06cc66647fd892275a6b495af68bcb5915a85858f37R348-R406) [[2]](diffhunk://#diff-a9b69a6e60e292a07754336a503ed3736a40e0213562734c300ca3539211f624R1219-R1232) [[3]](diffhunk://#diff-b37fb3fb67ae239d945e5244ef7591eeee1c4b4abb6f0c046de95b9716d03358R1120-R1131) [[4]](diffhunk://#diff-b37fb3fb67ae239d945e5244ef7591eeee1c4b4abb6f0c046de95b9716d03358R1176-R1238)
* Call state events are now recognized by specific prefixes, and the event buffer will remove any previously buffered call state events before adding a new one, preventing stale or duplicate state. [[1]](diffhunk://#diff-cd8db83ca5629b36aee8f06cc66647fd892275a6b495af68bcb5915a85858f37R102-R105) [[2]](diffhunk://#diff-cd8db83ca5629b36aee8f06cc66647fd892275a6b495af68bcb5915a85858f37R1616-R1618) [[3]](diffhunk://#diff-a9b69a6e60e292a07754336a503ed3736a40e0213562734c300ca3539211f624R50-R67) [[4]](diffhunk://#diff-a9b69a6e60e292a07754336a503ed3736a40e0213562734c300ca3539211f624R1286-R1294) [[5]](diffhunk://#diff-b37fb3fb67ae239d945e5244ef7591eeee1c4b4abb6f0c046de95b9716d03358R28-R41) [[6]](diffhunk://#diff-b37fb3fb67ae239d945e5244ef7591eeee1c4b4abb6f0c046de95b9716d03358R1176-R1238)

**Event Buffering and Delivery**

* All platforms implement a bounded event buffer (`pendingEvents`) for events raised before the Dart listener attaches, ensuring no events are lost and preventing unbounded growth. Buffered events are flushed to Dart when the listener attaches. [[1]](diffhunk://#diff-cd8db83ca5629b36aee8f06cc66647fd892275a6b495af68bcb5915a85858f37R348-R406) [[2]](diffhunk://#diff-a9b69a6e60e292a07754336a503ed3736a40e0213562734c300ca3539211f624R50-R67) [[3]](diffhunk://#diff-a9b69a6e60e292a07754336a503ed3736a40e0213562734c300ca3539211f624R1219-R1232) [[4]](diffhunk://#diff-a9b69a6e60e292a07754336a503ed3736a40e0213562734c300ca3539211f624R1286-R1294) [[5]](diffhunk://#diff-b37fb3fb67ae239d945e5244ef7591eeee1c4b4abb6f0c046de95b9716d03358R28-R41) [[6]](diffhunk://#diff-b37fb3fb67ae239d945e5244ef7591eeee1c4b4abb6f0c046de95b9716d03358R1120-R1131) [[7]](diffhunk://#diff-b37fb3fb67ae239d945e5244ef7591eeee1c4b4abb6f0c046de95b9716d03358R1176-R1238)

**Custom Parameter Handling**

* The iOS and macOS implementations now properly track and emit custom call parameters as part of the call state event, ensuring Dart receives all relevant call metadata. [[1]](diffhunk://#diff-a9b69a6e60e292a07754336a503ed3736a40e0213562734c300ca3539211f624R742-R748) [[2]](diffhunk://#diff-a9b69a6e60e292a07754336a503ed3736a40e0213562734c300ca3539211f624R917-R918) [[3]](diffhunk://#diff-a9b69a6e60e292a07754336a503ed3736a40e0213562734c300ca3539211f624R1033) [[4]](diffhunk://#diff-a9b69a6e60e292a07754336a503ed3736a40e0213562734c300ca3539211f624R1187-R1189) [[5]](diffhunk://#diff-b37fb3fb67ae239d945e5244ef7591eeee1c4b4abb6f0c046de95b9716d03358R1176-R1238)

**Changelog Update**

* The `CHANGELOG.md` documents the fix for call state synchronization across Android, iOS, and macOS, referencing the related GitHub issue.

These changes collectively ensure reliable and accurate call state reporting to Dart, even in edge cases such as app cold starts, backgrounding, or late event listener attachment.