### PR TITLE
fix: fix persisting incoming call notification / missed call notification on outgoing calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next Release
 
+* fix: [Web] an incoming call not answered left a hanging incoming call notification indefinitely.
+* fix: [Web] an unanswered *outgoing* call ended early cancelled from this device is no longer reported as a missed call
 * fix: [Android, iOS, macOS] `isOnCall` & `activeCall` now sync. Launching app with ongoing call now returns correct `activeCall` object and `isOnCall` true. (see [Issue #179](https://github.com/cybex-dev/twilio_voice/issues/179))
 * chore: [Android] plugin Gradle wrapper raised to 8.11.1, the minimum for the declared AGP 8.9.1
 * fix: [Android] `setActive()` now proactively changes call UI to ongoing call screen when answering incoming call preventing perceived delay while connecting.

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -1060,16 +1060,20 @@ class Call extends MethodChannelTwilioCall {
     }
     // notify SW to cancel notification
     final callStatus = getCallStatus(jsCall);
+
+    // get call SID before reset
+    final callSid = _getSid();
+
     _detachCallEventListeners(jsCall);
     nativeCall = null;
     logLocalEvent("Call Ended", prefix: "");
 
     // reject incoming call that is both outbound ringing or inbound pending
     // TODO(cybex-dev): check call status for call disconnects
-    final callSid = _getSid();
-    if(callSid == null) {
+    if (callSid == null) {
       return;
     }
+
     if (callStatus == CallStatus.ringing || callStatus == CallStatus.pending || callStatus == CallStatus.closed) {
       logLocalEvent("Missed Call", prefix: "");
       webCallkit.reportCallDisconnected(callSid, response: CKDisconnectResponse.missed);

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -1058,23 +1058,20 @@ class Call extends MethodChannelTwilioCall {
     if (jsCall == null) {
       return;
     }
-    // notify SW to cancel notification
-    final callStatus = getCallStatus(jsCall);
 
     // get call SID before reset
     final callSid = _getSid();
+    final isIncoming = jsCall.direction == "INCOMING";
 
     _detachCallEventListeners(jsCall);
     nativeCall = null;
     logLocalEvent("Call Ended", prefix: "");
 
-    // reject incoming call that is both outbound ringing or inbound pending
-    // TODO(cybex-dev): check call status for call disconnects
     if (callSid == null) {
       return;
     }
 
-    if (callStatus == CallStatus.ringing || callStatus == CallStatus.pending || callStatus == CallStatus.closed) {
+    if (isIncoming) {
       logLocalEvent("Missed Call", prefix: "");
       webCallkit.reportCallDisconnected(callSid, response: CKDisconnectResponse.missed);
     } else {


### PR DESCRIPTION
This pull request addresses issues with call notifications and missed call reporting on the web platform. The main improvements ensure that incoming and outgoing call notifications are correctly cleared and that missed call events are accurately reported.

Web call notification and missed call handling:

* Fixed an issue where an unanswered incoming call left a hanging notification indefinitely.
* Fixed a bug where an unanswered outgoing call that ended early (cancelled from this device) was incorrectly reported as a missed call. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R4) [[2]](diffhunk://#diff-ec6e948d7a10d3f7a327011474bd335b572a8b9bc2864cef0c29afe08c4a5140L1061-R1074)
* Refactored call end handling in `twilio_voice_web.dart` to distinguish between incoming and outgoing calls, ensuring missed call events and notifications are handled appropriately.