### PR TITLE
feat: interpret call parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Next Release
 
+* feat: [iOS] incoming calls now lookup a contact:
+  * e.g. `from:+1...` - contact lookup by phone app using [CXHandle.HandleType.phoneNumber](https://developer.apple.com/documentation/callkit/cxhandle/handletype/phonenumber)
+  * e.g. `from:client:id` - the plugin resolves the client's id with [CXHandle.HandleType.generic](https://developer.apple.com/documentation/callkit/cxhandle/handletype/generic)
+    * note: [iOS, macOS] an unregistered client with no name parameter now shows the default caller name
+    ("Unknown Caller") where it previously showed the raw client id, matching Android.
+* feat: [iOS, macOS, Web] added remaining platforms caller name resolution based on documented
+  [Interpreting Parameters](https://github.com/cybex-dev/twilio_voice#interpreting-parameters) rules: 
+  - custom parameters: `__TWI_CALLER_NAME`, or 
+  - resolve(`__TWI_CALLER_ID`), or
+  - phone number / registered client, or fallback
+  - default caller name.
 * fix: [Web] an incoming call not answered left a hanging incoming call notification indefinitely.
 * fix: [Web] an unanswered *outgoing* call ended early cancelled from this device is no longer reported as a missed call
 * fix: [Android, iOS, macOS] `isOnCall` & `activeCall` now sync. Launching app with ongoing call now returns correct `activeCall` object and `isOnCall` true. (see [Issue #179](https://github.com/cybex-dev/twilio_voice/issues/179))

--- a/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/service/TVConnectionService.kt
@@ -60,8 +60,6 @@ class TVConnectionService : ConnectionService() {
 
         private const val MAX_CANCELLED_CALL_INVITES = 32
 
-        val TWI_SCHEME: String = "twi"
-
         /**
          * Notification id used for the foreground-service (ongoing call) notification.
          */

--- a/android/src/main/kotlin/com/twilio/twilio_voice/types/TelecomManagerExtension.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/types/TelecomManagerExtension.kt
@@ -51,7 +51,6 @@ object TelecomManagerExtension {
         val phoneAccount = PhoneAccount.builder(phoneAccountHandle, label)
             .setCapabilities(PhoneAccount.CAPABILITY_CALL_PROVIDER or PhoneAccount.CAPABILITY_CONNECTION_MANAGER or PhoneAccount.CAPABILITY_CALL_SUBJECT)
             .setShortDescription(description)
-//            .addSupportedUriScheme(TVConnectionService.TWI_SCHEME)
             .setIcon(Icon.createWithResource(ctx, ctx.applicationInfo.icon))
             .addSupportedUriScheme(PhoneAccount.SCHEME_TEL)
             .build()

--- a/ios/twilio_voice/Sources/twilio_voice/SwiftTwilioVoicePlugin.swift
+++ b/ios/twilio_voice/Sources/twilio_voice/SwiftTwilioVoicePlugin.swift
@@ -1130,9 +1130,18 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         clients["defaultCaller"] ?? defaultCaller
     }
 
+    /// Whether a handle is a dialable number rather than a client identity.
+    private func isPhoneNumber(_ handle: String) -> Bool {
+        if handle.hasPrefix("client:") { return false }
+        let digits = handle.hasPrefix("+") ? String(handle.dropFirst()) : handle
+        return !digits.isEmpty && digits.allSatisfy { $0.isNumber }
+    }
+
     func reportIncomingCall(from: String, uuid: UUID, params: [String: Any]? = nil) {
         // The handle is the raw identity; the display name is resolved separately.
-        let callHandle = CXHandle(type: .generic, value: from.replacingOccurrences(of: "client:", with: ""))
+        let callHandle = isPhoneNumber(from)
+            ? CXHandle(type: .phoneNumber, value: from)
+            : CXHandle(type: .generic, value: from.replacingOccurrences(of: "client:", with: ""))
 
         let callUpdate = CXCallUpdate()
         callUpdate.remoteHandle = callHandle

--- a/ios/twilio_voice/Sources/twilio_voice/SwiftTwilioVoicePlugin.swift
+++ b/ios/twilio_voice/Sources/twilio_voice/SwiftTwilioVoicePlugin.swift
@@ -737,7 +737,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
 
         self.sendPhoneCallEvents(description: "Incoming|\(from)|\(callInvite.to)|Incoming\(formatCustomParams(params: callInvite.customParameters))", isError: false)
         self.sendPhoneCallEvents(description: "Ringing|\(from)|\(callInvite.to)|Incoming\(formatCustomParams(params: callInvite.customParameters))", isError: false)
-        reportIncomingCall(from: from, uuid: callInvite.uuid)
+        reportIncomingCall(from: callInvite.from ?? "", uuid: callInvite.uuid, params: callInvite.customParameters)
         self.callInvite = callInvite
         self.customParameters = callInvite.customParameters
     }
@@ -1096,20 +1096,47 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
         }
     }
 
-    func reportIncomingCall(from: String, uuid: UUID) {
-        let callHandle = CXHandle(type: .generic, value: from)
-
-        var callerName: String?;
-        if(from.contains("client:")) {
-            var clientName = from.replacingOccurrences(of: "client:", with: "")
-            callerName = self.clients[clientName];
-        } else {
-            callerName = from
+    /// Resolves the name shown on the call screen, per the Interpreting Parameters contract:
+    /// `__TWI_CALLER_NAME` -> resolve(`__TWI_CALLER_ID`) -> phone number -> registered client ->
+    /// default caller name.
+    ///
+    /// - Parameter handle: the raw `from`, e.g. `client:alice` or `+15551234567`.
+    /// - Parameter params: the call's custom parameters.
+    func resolveCallerName(handle: String, params: [String: Any]? = nil) -> String {
+        if let name = params?["__TWI_CALLER_NAME"] as? String, !name.isEmpty {
+            return name
         }
+        if let id = params?["__TWI_CALLER_ID"] as? String, !id.isEmpty {
+            return resolveRegisteredClient(id)
+        }
+        if handle.isEmpty {
+            return defaultCallerName
+        }
+        // A number is shown as-is; only client identities are looked up.
+        if !handle.hasPrefix("client:") {
+            return handle
+        }
+        return resolveRegisteredClient(handle)
+    }
+
+    /// Registered client name for an id, or the default caller name if it is not registered.
+    private func resolveRegisteredClient(_ id: String) -> String {
+        let clientId = id.replacingOccurrences(of: "client:", with: "")
+        return clients[clientId] ?? defaultCallerName
+    }
+
+    /// The configured default caller name, falling back to the built-in "Unknown Caller".
+    private var defaultCallerName: String {
+        clients["defaultCaller"] ?? defaultCaller
+    }
+
+    func reportIncomingCall(from: String, uuid: UUID, params: [String: Any]? = nil) {
+        // The handle is the raw identity; the display name is resolved separately.
+        let callHandle = CXHandle(type: .generic, value: from.replacingOccurrences(of: "client:", with: ""))
 
         let callUpdate = CXCallUpdate()
         callUpdate.remoteHandle = callHandle
-        callUpdate.localizedCallerName = callerName ?? self.clients["defaultCaller"] ?? defaultCaller
+        callUpdate.localizedCallerName = resolveCallerName(handle: from, params: params)
         callUpdate.supportsDTMF = true
         callUpdate.supportsHolding = true
         callUpdate.supportsGrouping = false

--- a/lib/_internal/twilio_voice_web.dart
+++ b/lib/_internal/twilio_voice_web.dart
@@ -533,14 +533,37 @@ class TwilioVoiceWeb extends MethodChannelTwilioVoice {
     _showIncomingCallNotification(call);
   }
 
+  /// Shown when no name resolves and no default caller name has been configured.
+  static const String _kUnknownCaller = "Unknown Caller";
+
+  /// Resolves the name shown for a call, per the Interpreting Parameters contract:
+  /// `__TWI_CALLER_NAME` -> resolve(`__TWI_CALLER_ID`) -> phone number -> registered client ->
+  /// default caller name. Android is the reference implementation (see TVParametersImpl).
   String _resolveCallerName(Map<String, String> params) {
+    final name = params["__TWI_CALLER_NAME"];
+    if (name != null && name.isNotEmpty) {
+      return name;
+    }
+    final id = params["__TWI_CALLER_ID"];
+    if (id != null && id.isNotEmpty) {
+      return _resolveRegisteredClient(id);
+    }
+
     final from = params["From"] ?? "";
-    if (from.startsWith("client:")) {
-      final clientName = from.substring(7);
-      return _localStorage.getRegisteredClient(clientName) ?? _localStorage.getDefaultCallerName(clientName);
-    } else {
+    if (from.isEmpty) {
+      return _localStorage.getDefaultCallerName(_kUnknownCaller);
+    }
+    // A number is shown as-is; only client identities are looked up.
+    if (!from.startsWith("client:")) {
       return from;
     }
+    return _resolveRegisteredClient(from);
+  }
+
+  /// Registered client name for an id, or the default caller name if it is not registered.
+  String _resolveRegisteredClient(String id) {
+    final clientId = id.startsWith("client:") ? id.substring(7) : id;
+    return _localStorage.getRegisteredClient(clientId) ?? _localStorage.getDefaultCallerName(_kUnknownCaller);
   }
 
   String? _resolveImageUrl(Map<String, String> params) {

--- a/macos/twilio_voice/Sources/twilio_voice/TwilioVoicePlugin.swift
+++ b/macos/twilio_voice/Sources/twilio_voice/TwilioVoicePlugin.swift
@@ -170,13 +170,33 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
         showNotification(title: from, subtitle: "Incoming Call", action: .incoming, params: customParameters)
     }
 
-    private func resolveCallerName(_ from: String) -> String {
-        if (from).starts(with: "client:") {
-            let clientName = from.replacingOccurrences(of: "client:", with: "")
-            return clients[clientName] ?? clientName
-        } else {
+    /// Resolves the name shown for a call, per the Interpreting Parameters contract:
+    /// `__TWI_CALLER_NAME` -> resolve(`__TWI_CALLER_ID`) -> phone number -> registered client ->
+    /// default caller name.
+    ///
+    /// - Parameter from: the raw handle, e.g. `client:alice` or `+15551234567`.
+    /// - Parameter params: the call's custom parameters.
+    private func resolveCallerName(_ from: String, _ params: [String: Any]? = nil) -> String {
+        if let name = params?["__TWI_CALLER_NAME"] as? String, !name.isEmpty {
+            return name
+        }
+        if let id = params?["__TWI_CALLER_ID"] as? String, !id.isEmpty {
+            return resolveRegisteredClient(id)
+        }
+        if from.isEmpty {
+            return defaultCaller
+        }
+        // A number is shown as-is; only client identities are looked up.
+        if !from.starts(with: "client:") {
             return from
         }
+        return resolveRegisteredClient(from)
+    }
+
+    /// Registered client name for an id, or the default caller name if it is not registered.
+    private func resolveRegisteredClient(_ id: String) -> String {
+        let clientId = id.replacingOccurrences(of: "client:", with: "")
+        return clients[clientId] ?? defaultCaller
     }
 
     /// Register device token with Twilio. If an active TwilioDevice is found, it attempts to update the token instead. Completion handler completes with true if successful
@@ -1385,11 +1405,12 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
                     print("Error: \(error)")
                 }
                 if let params = params {
-                    let from = self.resolveCallerName(params.from ?? "")
+                    let from = params.from ?? ""
                     let to = params.to ?? ""
                     self.logEvents(prefix: "", descriptions: ["Incoming", from, to, "Incoming", self.formatCustomParams(params: params.customParameters)])
                     self.logEvents(prefix: "", descriptions: ["Ringing", from, to, "Incoming", self.formatCustomParams(params: params.customParameters)])
-                    self.showIncomingCallNotification(from, params.customParameters)
+                    // The event carries the raw handle; only the notification shows the resolved name.
+                    self.showIncomingCallNotification(self.resolveCallerName(from, params.customParameters), params.customParameters)
                 }
             }
         }


### PR DESCRIPTION
This pull request introduces improved and unified logic for resolving and displaying caller names on incoming calls across iOS, macOS, and Web platforms. The changes ensure that the caller name is determined following a consistent and documented priority: custom parameter, registered client, phone number, or a default fallback. Additionally, some minor code cleanups were made on Android.

### Caller name resolution improvements

* **iOS:** Incoming calls now resolve and display the caller name using the following priority: `__TWI_CALLER_NAME` custom parameter, then `__TWI_CALLER_ID` (registered client), then phone number, then default caller name ("Unknown Caller"). The logic uses the correct `CXHandle` type for phone numbers and clients. [[1]](diffhunk://#diff-a9b69a6e60e292a07754336a503ed3736a40e0213562734c300ca3539211f624L1099-R1148) [[2]](diffhunk://#diff-a9b69a6e60e292a07754336a503ed3736a40e0213562734c300ca3539211f624L740-R740)
* **macOS:** Incoming call notifications use the same caller name resolution logic as iOS, ensuring consistency and correct fallback to the default caller name. [[1]](diffhunk://#diff-b37fb3fb67ae239d945e5244ef7591eeee1c4b4abb6f0c046de95b9716d03358L173-R199) [[2]](diffhunk://#diff-b37fb3fb67ae239d945e5244ef7591eeee1c4b4abb6f0c046de95b9716d03358L1388-R1413)
* **Web:** The displayed caller name is now resolved per the same documented contract, including support for custom parameters and proper fallback to the default or "Unknown Caller".

### Documentation

* **Changelog:** Updated to document the new caller name resolution logic and behavior changes for iOS, macOS, and Web.

### Code cleanup (Android)

* **Android:** Removed the unused `TWI_SCHEME` constant and commented code related to URI schemes. [[1]](diffhunk://#diff-b939af2345bc2785c2f16f91ea6be6419cc87f49353c7207689b0ab0c3a9b225L63-L64) [[2]](diffhunk://#diff-7b092d5df6963cbd6616edd30a53b8626d40ab1904646c679330f5b09f19ff98L54)