### PR TITLE
fix: provide iOS raw `from`/`to` parameters & updated docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * feat: [iOS, macOS] Swift Package Manager support added, enable it with `flutter config --enable-swift-package-manager`. _Note: projects using CocoaPods will continue to use CocoaPods, and SPM is only used for new projects or those that have opted in._
 * feat: added call quality events for all platforms (see `CallQualityEvent` and `TwilioVoicePlatform.instance.call.qualityWarnings`, and [Twilio Call Quality Metrics](https://www.twilio.com/docs/voice/voice-insights/api/call/details-sdk-call-quality-events#error-and-warning-events))
 * fix: [android] fixed crash when `CallInvite` is received due to unmarshalling error with some Telecom/ConnectionService implementations (e.g. Samsung)
+* fix: [iOS] call events now provide raw `from`/`to` Twilio sent, `client:` prefix included. This is present on other platforms.
 * Updated Example
 * Updated docs
 

--- a/README.md
+++ b/README.md
@@ -497,7 +497,9 @@ These parameters above are interpreted as follows.
 
 #### Name resolution
 
-Caller is usually referred to as `call.from` or `callInvite.from`. This can either be a number of a string (with the format `client:clientName`) or null.
+Caller is usually referred to as `call.from` or `callInvite.from`. This can either be a number of a string (with the format `client:clientName`) or null. 
+
+_Note: All platforms provide the raw `from`/`to` values in call events stream i.e. (`TwilioVoicePlatform.instance.callEventsListener`) allowing the developer to interpret these as needed._
 
 The following rules are applied to determine the caller/recipient name, which is shown in the call screen and heads-up notification:
 

--- a/ios/twilio_voice/Sources/twilio_voice/SwiftTwilioVoicePlugin.swift
+++ b/ios/twilio_voice/Sources/twilio_voice/SwiftTwilioVoicePlugin.swift
@@ -722,8 +722,9 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
          */
         UserDefaults.standard.set(Date(), forKey: kCachedBindingDate)
         
-        var from:String = callInvite.from ?? defaultCaller
-        from = from.replacingOccurrences(of: "client:", with: "")
+        // Reported to Dart exactly as Twilio sent it, `client:` prefix included - the events carry
+        // the handle, not a display name. Resolving one is reportIncomingCall's job.
+        let from: String = callInvite.from ?? ""
 
         // Check if the user has allowed incoming calls while busy. If not, reject the call invite if there is an active call or call invite.
         // Ensure we report a failed call to CallKit.
@@ -813,8 +814,10 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
     // MARK: TVOCallDelegate
     public func callDidStartRinging(call: Call) {
         let direction = (self.callOutgoing ? "Outgoing" : "Incoming")
-        let from = (call.from ?? self.identity)
-        let to = (call.to ?? self.callTo)
+        // Raw handles: substituting our own identity/dialled number would report values Twilio
+        // never sent, which Android and web do not do.
+        let from = call.from ?? ""
+        let to = call.to ?? ""
         self.sendPhoneCallEvents(description: "Ringing|\(from)|\(to)|\(direction)", isError: false)
 
         //self.placeCallButton.setTitle("Ringing", for: .normal)
@@ -822,8 +825,8 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
 
     public func callDidConnect(call: Call) {
         let direction = (self.callOutgoing ? "Outgoing" : "Incoming")
-        let from = (call.from ?? self.identity)
-        let to = (call.to ?? self.callTo)
+        let from = call.from ?? ""
+        let to = call.to ?? ""
         self.sendPhoneCallEvents(description: "Connected|\(from)|\(to)|\(direction)", isError: false)
 
         if let callKitCompletionCallback = callKitCompletionCallback {
@@ -1285,8 +1288,8 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
     private func emitActiveCallState() {
         if let activeCall = self.call, activeCall.state == .connected || activeCall.state == .reconnecting {
             let direction = self.callOutgoing ? "Outgoing" : "Incoming"
-            let from = (activeCall.from ?? self.identity).replacingOccurrences(of: "client:", with: "")
-            let to = activeCall.to ?? self.callTo
+            let from = activeCall.from ?? ""
+            let to = activeCall.to ?? ""
             NSLog("Emitting state of active call for the new listener")
             self.sendPhoneCallEvents(description: "Connected|\(from)|\(to)|\(direction)\(formatCustomParams(params: self.customParameters))", isError: false)
 
@@ -1297,7 +1300,7 @@ public class SwiftTwilioVoicePlugin: NSObject, FlutterPlugin,  FlutterStreamHand
                 self.sendPhoneCallEvents(description: "Reconnecting", isError: false)
             }
         } else if let invite = self.callInvite {
-            let from = (invite.from ?? self.defaultCaller).replacingOccurrences(of: "client:", with: "")
+            let from = invite.from ?? ""
             NSLog("Emitting state of ringing call for the new listener")
             self.sendPhoneCallEvents(description: "Incoming|\(from)|\(invite.to)|Incoming\(formatCustomParams(params: invite.customParameters))", isError: false)
         }


### PR DESCRIPTION
This pull request standardizes how the `from` and `to` fields are handled in iOS call events, ensuring they now provide the raw values as sent by Twilio (including the `client:` prefix when present), matching behavior on other platforms. This improves consistency and gives developers access to the unmodified identifiers for calls. Documentation has also been updated to reflect this change.

### iOS Call Event Consistency

* The `from` and `to` fields in iOS call events are now reported exactly as received from Twilio, including the `client:` prefix, rather than stripping or substituting these values. This affects all event emissions, including incoming call invites, ringing, connected events, and active call state reporting. [[1]](diffhunk://#diff-a9b69a6e60e292a07754336a503ed3736a40e0213562734c300ca3539211f624L725-R727) [[2]](diffhunk://#diff-a9b69a6e60e292a07754336a503ed3736a40e0213562734c300ca3539211f624L816-R829) [[3]](diffhunk://#diff-a9b69a6e60e292a07754336a503ed3736a40e0213562734c300ca3539211f624L1288-R1292) [[4]](diffhunk://#diff-a9b69a6e60e292a07754336a503ed3736a40e0213562734c300ca3539211f624L1300-R1303)
* The changelog has been updated to note that iOS call events now provide the raw `from`/`to` values, aligning with other platforms.

### Documentation

* The `README.md` has been updated to clarify that all platforms now provide the raw `from`/`to` values in the call events stream, allowing developers to interpret these as needed.