### PR TITLE
Fix/macos detach event listeners

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -288,7 +288,7 @@ class _AppState extends State<App> {
       switch (event) {
         case CallEvent.incoming:
         // applies to web only
-          if (kIsWeb || Platform.isAndroid) {
+          if (kIsWeb || Platform.isAndroid || Platform.isMacOS) {
             final activeCall = TwilioVoicePlatform.instance.call.activeCall;
             if (activeCall != null && activeCall.callDirection == CallDirection.incoming) {
               _showWebIncomingCallDialog();
@@ -416,8 +416,8 @@ class _AppState extends State<App> {
   }
 
   Future<bool?> showIncomingCallScreen(BuildContext context, ActiveCall activeCall) async {
-    if (!kIsWeb && !Platform.isAndroid) {
-      printDebug("showIncomingCallScreen only for web");
+    if (!(kIsWeb || Platform.isAndroid || Platform.isMacOS)) {
+      printDebug("showIncomingCallScreen only for web, macOS or Android");
       return false;
     }
 

--- a/macos/twilio_voice/Sources/twilio_voice/JsInterop/Call/TVCall.swift
+++ b/macos/twilio_voice/Sources/twilio_voice/JsInterop/Call/TVCall.swift
@@ -164,8 +164,6 @@ public class TVCall: JSObject, TVCallDelegate, JSMessageHandlerDelegate {
 
     /// Detach event listeners from JS [TVCall] events. Apply when [TVCall] is ended, or incoming call rejected/ignored or destroyed
     ///
-    /// NOTE(cybex-dev): JS .off() function not defined, so we cannot detach event listeners [Error] TypeError: _call.off is not a function. (In '_call.off('reconnected', _on_event__call_reconnected)', '_call.off' is undefined)
-    ///
     /// - SeeAlso Twilio [Call.Events](https://www.twilio.com/docs/voice/sdks/javascript/twiliocall#events)
     func detachEventListeners() {
         print("Detaching event listeners from [TVCall]")

--- a/macos/twilio_voice/Sources/twilio_voice/JsInterop/Call/TVCall.swift
+++ b/macos/twilio_voice/Sources/twilio_voice/JsInterop/Call/TVCall.swift
@@ -59,14 +59,25 @@ public class TVCall: JSObject, TVCallDelegate, JSMessageHandlerDelegate {
     /// - Parameter completionHandler: completion handler
     /// - SeeAlso Twilio [Call.customParameters](https://www.twilio.com/docs/voice/sdks/javascript/twiliocall#callcustomparameters)
     func customParameters(completionHandler: @escaping OnCompletionHandler<[String: Any]>) {
-        property(ofType: Dictionary<String, Any>.self, name: "customParameters") { (result, error) in
+        // Twilio exposes this as a JS Map, which WKWebView cannot marshal - reading the property
+        // directly always yields nothing. Convert it to a plain object first. For outgoing calls
+        // this is also where From/To live, as Call.parameters only carries them for incoming.
+        let JS = """
+                 if (\(jsObjectName) && \(jsObjectName).customParameters instanceof Map) {
+                    Object.fromEntries(\(jsObjectName).customParameters);
+                 } else if (\(jsObjectName) && \(jsObjectName).customParameters) {
+                    \(jsObjectName).customParameters;
+                 } else {
+                    ({});
+                 }
+                 """
+        webView.evaluateJavaScript(javascript: JS, sourceURL: "\(jsObjectName)_customParameters") { result, error in
             if let error = error {
                 print(error)
                 completionHandler(nil, error)
+                return
             }
-            if let result = result {
-                completionHandler(result, nil)
-            }
+            completionHandler(result as? [String: Any] ?? [:], nil)
         }
     }
 
@@ -223,7 +234,11 @@ public class TVCall: JSObject, TVCallDelegate, JSMessageHandlerDelegate {
             self.customParameters { dictionary, s in
                 if let dictionary = dictionary {
                     dictionary.forEach({ (key, value) in
-                        params[key] = value
+                        // Twilio's own parameters are authoritative; custom params only fill gaps,
+                        // which is what supplies From/To on an outgoing call.
+                        if params[key] == nil {
+                            params[key] = value
+                        }
                     })
                 }
 

--- a/macos/twilio_voice/Sources/twilio_voice/JsInterop/Call/TVCall.swift
+++ b/macos/twilio_voice/Sources/twilio_voice/JsInterop/Call/TVCall.swift
@@ -168,7 +168,7 @@ public class TVCall: JSObject, TVCallDelegate, JSMessageHandlerDelegate {
     func detachEventListeners() {
         print("Detaching event listeners from [TVCall]")
         detachMessageHandler()
-        let events: [TVCallEvent] = [.accept, .cancel, .disconnect, .error, .reconnecting, .reconnected, .reject, .ringing]
+        let events: [TVCallEvent] = [.accept, .cancel, .disconnect, .error, .reconnecting, .reconnected, .reject, .ringing, .warning, .warningCleared]
         events.map {
                     $0.rawValue
                 }

--- a/macos/twilio_voice/Sources/twilio_voice/TwilioVoicePlugin.swift
+++ b/macos/twilio_voice/Sources/twilio_voice/TwilioVoicePlugin.swift
@@ -144,7 +144,6 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
         // CallKit has an odd API contract where the developer must call invalidate or the CXProvider is leaked.
         twilioDevice?.dispose()
         twilioDevice = nil
-        twilioCall?.dispose()
         twilioCall = nil
     }
 
@@ -1491,7 +1490,6 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
             }
         }
 
-        twilioCall?.dispose()
         twilioCall = nil
         logEvent(prefix: "", description: "Missed Call")
         logEvent(prefix: "", description: "Call Ended")
@@ -1509,7 +1507,6 @@ public class TwilioVoicePlugin: NSObject, FlutterPlugin, FlutterStreamHandler, T
             }
         }
 
-        twilioCall?.dispose()
         twilioCall = nil
     }
 

--- a/macos/twilio_voice/Sources/twilio_voice/Types/JSObject.swift
+++ b/macos/twilio_voice/Sources/twilio_voice/Types/JSObject.swift
@@ -98,9 +98,16 @@ public class JSObject: NSObject, WKScriptMessageHandler, Disposable {
     /// }
     /// _device.on('ready', _on_event__device_ready);
     /// ```
+    /// JS variable name holding the handler for [event]. Event names may contain characters that
+    /// are invalid in a JS identifier (e.g. `warning-cleared`), so they are replaced with `_`.
+    private func handlerVariableName(_ event: String) -> String {
+        let sanitized = String(event.map { $0.isLetter || $0.isNumber || $0 == "_" ? $0 : "_" })
+        return "_on_event_\(jsObjectName)_\(sanitized)"
+    }
+
     func addEventListener(_ event: String, onTriggeredAction: String? = nil, completionHandler: OnCompletionHandler<Bool>? = nil) {
         print("[\(jsObjectName)] Adding event listener: \(event)")
-        let eventName = "_on_event_\(jsObjectName)_\(event)"
+        let eventName = handlerVariableName(event)
 //        guard !JSObject.activeEventHandlers.contains(where: { key, value in key == jsObjectName && value == event }) else {
 //            completionHandler?(true, "Event listener already exists, skipping.")
 //            return
@@ -143,7 +150,7 @@ public class JSObject: NSObject, WKScriptMessageHandler, Disposable {
     /// ```
     func removeEventListener(_ event: String, completionHandler: OnCompletionHandler<Bool>? = nil) {
         print("[\(jsObjectName)] Removing event listener: \(event)")
-        let eventName = "_on_event_\(jsObjectName)_\(event)"
+        let eventName = handlerVariableName(event)
 //        guard JSObject.activeEventHandlers.contains(where: { key, value in key == jsObjectName && value == event }) else {
 //            completionHandler?(true, "Event listener not found, skipping.")
 //            return

--- a/macos/twilio_voice/Sources/twilio_voice/Types/JSObject.swift
+++ b/macos/twilio_voice/Sources/twilio_voice/Types/JSObject.swift
@@ -144,7 +144,7 @@ public class JSObject: NSObject, WKScriptMessageHandler, Disposable {
     /// - Example:
     /// ```
     /// if (typeof _on_event__device_ready !== 'undefined') {
-    ///    device.off('ready', _on_event__device_ready);
+    ///    device.removeListener('ready', _on_event__device_ready);
     /// }
     /// delete _on_event__device_ready;
     /// ```
@@ -159,7 +159,7 @@ public class JSObject: NSObject, WKScriptMessageHandler, Disposable {
         let JS = """
                     log("🔹", 'removeEventListener: \(event)');
                     if (typeof \(eventName) !== 'undefined') {
-                        \(jsObjectName).off('\(event)', \(eventName));
+                        \(jsObjectName).removeListener('\(event)', \(eventName));
                         delete \(eventName); true;
                     }
                  """


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the Twilio Voice Flutter plugin, particularly for macOS support and JavaScript interop. The most significant changes include expanded platform support for incoming calls, improved handling of custom parameters in JS interop, more robust event listener management, and some code cleanup for call disposal.

**Platform support improvements:**

* Incoming call handling is now enabled for macOS in addition to web and Android by updating platform checks in `_AppState` (`main.dart`). [[1]](diffhunk://#diff-72fd825ad17ce7800a2078e06f0dff1e12836ee59760465e78d9a5d222cebd15L291-R291) [[2]](diffhunk://#diff-72fd825ad17ce7800a2078e06f0dff1e12836ee59760465e78d9a5d222cebd15L419-R420)

**JavaScript interop and event listener management:**

* The `customParameters` method in `TVCall.swift` now correctly handles Twilio's JS Map by converting it to a plain object, ensuring parameters are accessible on macOS. Also, custom parameters only fill gaps not covered by Twilio's authoritative parameters. [[1]](diffhunk://#diff-eeb06a672716dc347a14a0b21c61813ae4783391c73d2b7e7aa090ff4b5b43ecL62-R80) [[2]](diffhunk://#diff-eeb06a672716dc347a14a0b21c61813ae4783391c73d2b7e7aa090ff4b5b43ecR237-R241)
* Event listener handler variable names are now sanitized to handle event names with invalid JS identifier characters, and removal uses `removeListener` instead of `off` for better compatibility. [[1]](diffhunk://#diff-458435da04fda6de3c5426653cd7df41c892a7180ebdccdf89af314b966a8a29R101-R110) [[2]](diffhunk://#diff-458435da04fda6de3c5426653cd7df41c892a7180ebdccdf89af314b966a8a29L140-R153) [[3]](diffhunk://#diff-458435da04fda6de3c5426653cd7df41c892a7180ebdccdf89af314b966a8a29L155-R162)

**Twilio event support:**

* The set of detached events in `detachEventListeners` was expanded to include `warning` and `warningCleared` events.

**Code cleanup:**

* Redundant calls to `twilioCall?.dispose()` were removed from `TwilioVoicePlugin.swift` to prevent unnecessary disposal. [[1]](diffhunk://#diff-b37fb3fb67ae239d945e5244ef7591eeee1c4b4abb6f0c046de95b9716d03358L147) [[2]](diffhunk://#diff-b37fb3fb67ae239d945e5244ef7591eeee1c4b4abb6f0c046de95b9716d03358L1494) [[3]](diffhunk://#diff-b37fb3fb67ae239d945e5244ef7591eeee1c4b4abb6f0c046de95b9716d03358L1512)